### PR TITLE
Image resize functionality on Konva and typing updates

### DIFF
--- a/src/actions/components.ts
+++ b/src/actions/components.ts
@@ -146,7 +146,6 @@ export const exportFiles = ({
   dispatch({
     type: EXPORT_FILES
   });
-
   createFiles(components, path, appName, exportAppBool)
     .then((dir: string) =>
       dispatch({

--- a/src/components/CodePreview.tsx
+++ b/src/components/CodePreview.tsx
@@ -26,7 +26,13 @@ class CodePreview extends Component<Props> {
         }}
       >
         <SyntaxHighlighter style={hybrid}>
-          {format(componentRender(focusComponent, components))}
+          {format(componentRender(focusComponent, components), {
+          singleQuote: true,
+          trailingComma: 'es5',
+          bracketSpacing: true,
+          jsxBracketSameLine: true,
+          parser: 'typescript'
+        })}
         </SyntaxHighlighter>
       </div>
     );

--- a/src/components/KonvaStage.tsx
+++ b/src/components/KonvaStage.tsx
@@ -2,10 +2,10 @@
 //and also the parent rectangle components.
 
 import React, { Component } from "react";
-import { Stage, Layer, Line, Image } from "react-konva";
-import Rectangle from "./Rectangle.tsx";
-import cloneDeep from "../utils/cloneDeep.ts";
-import { ComponentInt, ComponentsInt, ChildInt } from "../utils/Interfaces.ts";
+import { Stage, Layer, Line } from "react-konva";
+import Rectangle from "./Rectangle";
+import cloneDeep from "../utils/cloneDeep";
+import { ComponentInt, ComponentsInt, ChildInt } from "../utils/Interfaces";
 import isEmpty from '../utils/isEmpty';
 
 interface PropsInt {
@@ -25,6 +25,9 @@ interface PropsInt {
   focusChild: any;
   changeComponentFocusChild: any;
   deleteChild: any;
+  scaleX: number;
+  scaleY: number;
+  draggable: boolean;
 }
 
 interface StateInt {
@@ -208,9 +211,6 @@ class KonvaStage extends Component<PropsInt, StateInt> {
             }}
           >
             {this.state.grid}
-            <Image image={this.props.focusComponent.id === 1 ? image : null //only display background image if the focused component is <App>
-            } draggable width={this.state.stageWidth*0.8} height={this.state.stageHeight*0.9 } //for background image uploaded, fix to fit screen
-            />
             {!isEmpty(focusComponent) && this.getDirectChildrenCopy(focusComponent) 
               .map((child: ChildInt, i: number) => (
                 <Rectangle
@@ -232,9 +232,7 @@ class KonvaStage extends Component<PropsInt, StateInt> {
                   handleTransform={handleTransform}
                   draggable={true}
                   blockSnapSize={this.state.blockSnapSize}
-                  imageSource={
-                    child.htmlElement === "Image" && child.HTMLInfo.Src
-                  }
+                  image={this.props.focusComponent.id === 1 ? image : null}
                 />
               ))
               .sort((rectA, rectB) => {

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -31,9 +31,6 @@ const LeftColExpansionPanel = (props: any) => {
   } = props;
 
   const { title, id, color, stateful, classBased } = component;
-  useEffect(() => {
-    console.log('title: ', title);
-  });
 
   function isFocused() {
     return focusComponent.id === id ? 'focused' : '';

--- a/src/components/Rectangle.tsx
+++ b/src/components/Rectangle.tsx
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
+import Konva from 'konva';
 import { Rect, Group, Label, Text } from 'react-konva';
-import TransformerComponent from './TransformerComponent.tsx';
-import GrandchildRectangle from './GrandchildRectangle.tsx';
-import { ComponentsInt, ChildInt } from '../utils/Interfaces.ts';
-import { ComponentInt } from '../utils/Interfaces.ts';
+import TransformerComponent from './TransformerComponent';
+import GrandchildRectangle from './GrandchildRectangle';
+import { ComponentsInt, ChildInt } from '../utils/Interfaces';
+import { ComponentInt } from '../utils/Interfaces';
 
 interface PropsInt {
   x: number;
@@ -22,18 +23,12 @@ interface PropsInt {
   draggable: boolean;
   blockSnapSize: number;
   childType: string;
-  imageSource: string;
   handleTransform: any;
+  image: HTMLImageElement;
 }
 
-interface StateInt {
-  image: any;
-}
 
-class Rectangle extends Component<PropsInt, StateInt> {
-  state = {
-    image: null
-  };
+class Rectangle extends Component<PropsInt> {
 
   getComponentColor(componentId: number) {
     const color = this.props.components.find((comp: ComponentInt) => comp.id === componentId).color;
@@ -46,8 +41,8 @@ class Rectangle extends Component<PropsInt, StateInt> {
     );
   }
 
-  handleResize(componentId: number, childId: number, target: any, blockSnapSize: number) {
-    let focChild: ChildInt = this.props.components
+  handleResize(componentId: number, childId: number, target: Konva.Group, blockSnapSize: number) {
+    let focChild: ChildInt | ComponentInt = this.props.components
       .find((comp: ComponentInt) => comp.id === this.props.componentId)
       .childrenArray.find((child: ChildInt) => child.childId === childId);
 
@@ -65,21 +60,13 @@ class Rectangle extends Component<PropsInt, StateInt> {
     this.props.handleTransform(componentId, childId, transformation);
   }
 
-  handleDrag(componentId: number, childId: number, target: any, blockSnapSize: any) {
+  handleDrag(componentId: number, childId: number, target: Konva.Group, blockSnapSize: number) {
     const transformation = {
       x: Math.round(target.x() / blockSnapSize) * blockSnapSize,
       y: Math.round(target.y() / blockSnapSize) * blockSnapSize
     };
     this.props.handleTransform(componentId, childId, transformation);
   }
-
-  setImage = (imageSource: string): void => {
-    if (!imageSource) return;
-    const image = new window.Image();
-    image.src = imageSource;
-    if (!image.height) return null;
-    this.setState({ image });
-  };
 
   render() {
     const {
@@ -98,8 +85,7 @@ class Rectangle extends Component<PropsInt, StateInt> {
       components,
       draggable,
       blockSnapSize,
-      childType,
-      imageSource
+      childType
     } = this.props;
 
     // the Group is responsible for dragging of all children
@@ -145,9 +131,9 @@ class Rectangle extends Component<PropsInt, StateInt> {
           draggable={false}
           fill={null}
           shadowBlur={childId === -1 ? 6 : null}
-          fillPatternImage={this.state.image ? this.state.image : null}
-          fillPatternScaleX={this.state.image ? width / this.state.image.width : 1}
-          fillPatternScaleY={this.state.image ? height / this.state.image.height : 1}
+          fillPatternImage={childId === -1  ? this.props.image : null} //spooky addition, image if uploaded will only be background of App component
+          fillPatternScaleX={this.props.image ? width / this.props.image.width : 1}
+          fillPatternScaleY={this.props.image? height / this.props.image.height : 1}
           _useStrictMode
         />
         <Label>
@@ -175,7 +161,6 @@ class Rectangle extends Component<PropsInt, StateInt> {
                 componentId={componentId}
                 directParentName={childComponentName}
                 childType={grandchild.childType}
-                imageSource={grandchild.htmlElement === 'Image' && grandchild.HTMLInfo.Src}
                 childComponentName={grandchild.componentName}
                 childComponentId={grandchild.childComponentId}
                 focusChild={focusChild}
@@ -195,7 +180,7 @@ class Rectangle extends Component<PropsInt, StateInt> {
               />
             ))}
         {focusChild && focusChild.childId === childId && draggable && (
-          <TransformerComponent
+          <TransformerComponent //This is the component that binds the Rect nodes to the Transformer node so they can be resized.
             focusChild={focusChild}
             rectClass={'childRect'}
             anchorSize={8}

--- a/src/components/SimpleModal.tsx
+++ b/src/components/SimpleModal.tsx
@@ -70,7 +70,7 @@ const SimpleModal = (props: any) => {
           >
             <CloseIcon />
           </IconButton>
-          <Typography variant="title" id="modal-title">
+          <Typography variant="h6" id="modal-title">
             {message}
           </Typography>
           <div>{children}</div>

--- a/src/containers/MainContainer.tsx
+++ b/src/containers/MainContainer.tsx
@@ -15,6 +15,7 @@ import {
 import KonvaStage from "../components/KonvaStage";
 import { ComponentInt, ComponentsInt } from "../utils/Interfaces";
 import * as actions from '../actions/components';
+import { changeImageSource } from "../utils/componentReducer.util";
 
 interface PropsInt {
   image: HTMLImageElement | null;

--- a/src/utils/componentRender.util.ts
+++ b/src/utils/componentRender.util.ts
@@ -150,8 +150,9 @@ const componentRender = (component: ComponentInt, components: ComponentsInt) => 
           : ``
       }
 
-      const {${props.map(el => el.key).join(', ')}} = props;
+
       ${classBased ? `render() {` : ``}
+      const {${props.map(el => el.key).join(', ')}} = ${classBased ? `this.props;` : `props;`}
       return (
         <div>
         ${cloneDeep(childrenArray)

--- a/src/utils/createFiles.util.ts
+++ b/src/utils/createFiles.util.ts
@@ -41,7 +41,7 @@ const createFiles = (components: any, path: string, appName: string, exportAppBo
 
     promises.push(newPromise);
   });
-
+  console.log(promises);
   return Promise.all(promises);
 };
 

--- a/src/utils/createFiles.util.ts
+++ b/src/utils/createFiles.util.ts
@@ -46,7 +46,6 @@ const createFiles = (
 
     promises.push(newPromise);
   });
-  console.log(promises);
   return Promise.all(promises);
 };
 


### PR DESCRIPTION
**Problem** Current image template upload functionality uses an Image component from Konva that is not bound to the transformer so is only draggable

**Solution** Set image to App component pattern image instead that adjusts with the Rect component bound to the App component

**Updates**

- Deleted index.js for types and reducers again that was reuploaded by mistake by someone

- Added prettier format parameters for code preview

-KonvaStage Image component removed, added image to fill pattern of the App component instead

-Warning for deprecated typography in Material-UI resolved

- Removed functions for setting the image in components that weren't being called anywhere