### PR TITLE
Touched up component card animation and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "Sean Sadykoff",
     "Shlomo Porges",
     "Sophia Huttner",
-    "Tolga Mizrakci",  
+    "Tolga Mizrakci",
     "Tony Ito-Cole"
-    ],
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/team-reactype/ReacType"
@@ -134,6 +134,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "clean-webpack-plugin": "^0.1.19",
+    "concurrently": "^5.1.0",
     "copy-webpack-plugin": "^4.5.2",
     "cross-env": "^5.2.0",
     "css-loader": "^0.28.11",

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -79,7 +79,8 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
           {/* {This is the component responsible for the collapsing transition animation for each component card} */}
           <Collapse
             in={focusedToggle}
-            collapsedHeight={70} //The type for the Collapse component is asking for a string, but if you put in a string and not a number, the component itself breaks.
+            collapsedHeight={'70px'}
+            timeout={500} //The type for the Collapse component is asking for a string, but if you put in a string and not a number, the component itself breaks.
           >
             {/* NOT SURE WHY COLOR: RED IS USED, TRIED REMOVING IT AND NO VISIBLE CHANGE OCCURED. */}
             <Grid


### PR DESCRIPTION
**Updates**

- A small update to the component card collapse animation so the transition looks smoother. The transition is now set to 500ms so it doesn't look so glitchy. Also, typing for the 'collapsedHeight' attribute was converted from integer to string with explicit pixel unit so TypeScript won't complain. (Looks like this is a bug, material UI docs say either number or string is fine. [See here](https://material-ui.com/api/collapse/) for more info. 

![Peek 2020-03-18 20-24](https://user-images.githubusercontent.com/14224294/77028777-0f6b8f80-6957-11ea-886e-e4440c8e1253.gif)


- Concurrently added as a dev dependency.