### PR TITLE
Fixed a bug in the tree graph

### DIFF
--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -124,7 +124,7 @@ class BottomTabs extends Component<BottomTabsPropsInt, StateInt> {
           this.generateComponentTree(child.childComponentId, components),
         );
       } else {
-        let str = { Type: 'HTML Component' };
+        let str = { Type: 'HTML Element' };
         tree.children.push({
           name: child.componentName,
           attributes: str,

--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -109,7 +109,9 @@ class BottomTabs extends Component<BottomTabsPropsInt, StateInt> {
   };
 
   handleClick = (event: any, node: any) => {
-    this.props.changeFocusComponent({ title: event.name });
+    if (!event.attributes.Type) {
+      this.props.changeFocusComponent({ title: event.name });
+    }
   };
 
   generateComponentTree(componentId: number, components: ComponentsInt) {
@@ -122,9 +124,10 @@ class BottomTabs extends Component<BottomTabsPropsInt, StateInt> {
           this.generateComponentTree(child.childComponentId, components),
         );
       } else {
+        let str = { Type: 'HTML Component' };
         tree.children.push({
           name: child.componentName,
-          attributes: {},
+          attributes: str,
           children: [],
         });
       }

--- a/src/utils/getSelectable.util.ts
+++ b/src/utils/getSelectable.util.ts
@@ -28,7 +28,7 @@ function findAncestors(
     };
   }
 
-  const newAncestors: Array<Number> = [];
+  const newAncestors: number[] = [];
 
   for (let i = 0; i < components.length; i++) {
     if (componentsToCheck.includes(components[i].id)) {


### PR DESCRIPTION
**Problem:**

- The app would crash if you would press on the node in the tree that represents HTML element and not a React component

**Solution:**

- Added an attribute that lists a Type to the nodes of the tree that represent HTML elements. That way on click we are able to differentiate the HTML element nodes from the  Component nodes. Adding an attribute also adds label to the HTML nodes