### PR TITLE
Undo/Redo functionality

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,6 +41,7 @@ function openFile() {
   mainWindow.webContents.send('new-file', file);
 }
 
+//functions to replace the default behavior of undo and redo
 function undo() {
   mainWindow.webContents.send('undo');
 }
@@ -118,7 +119,7 @@ const createWindow = () => {
       submenu: [
         { 
           label: 'Undo',
-          accelerator: process.platform === 'darwin' ? 'Cmd+Z' : 'Ctrl+Z',
+          accelerator: process.platform === 'darwin' ? 'Cmd+Z' : 'Ctrl+Z',  //these hotkeys are a tad bit glitchy
           click() {
             undo();
           }

--- a/main.js
+++ b/main.js
@@ -41,6 +41,10 @@ function openFile() {
   mainWindow.webContents.send('new-file', file);
 }
 
+function undo() {
+  mainWindow.webContents.send('undo');
+}
+
 function toggleTutorial() {
   mainWindow.webContents.send('tutorial_clicked');
 }
@@ -107,7 +111,13 @@ const createWindow = () => {
     {
       label: 'Edit',
       submenu: [
-        { role: 'undo' },
+        { 
+          label: 'Undo',
+          accelerator: process.platform === 'darwin' ? 'Command+Z' : 'Ctrl+Z',
+          click() {
+            undo();
+          }
+        },
         { role: 'redo' },
         { type: 'separator' },
         { role: 'cut' },

--- a/main.js
+++ b/main.js
@@ -45,6 +45,11 @@ function undo() {
   mainWindow.webContents.send('undo');
 }
 
+function redo() {
+  mainWindow.webContents.send('redo');
+}
+
+
 function toggleTutorial() {
   mainWindow.webContents.send('tutorial_clicked');
 }
@@ -113,12 +118,18 @@ const createWindow = () => {
       submenu: [
         { 
           label: 'Undo',
-          accelerator: process.platform === 'darwin' ? 'Command+Z' : 'Ctrl+Z',
+          accelerator: process.platform === 'darwin' ? 'Cmd+Z' : 'Ctrl+Z',
           click() {
             undo();
           }
         },
-        { role: 'redo' },
+        { 
+          label: 'Redo',
+          accelerator: process.platform === 'darwin' ? 'Cmd+Shift+Z' : 'Ctrl+Shift+Z',
+          click() {
+            redo();
+          }
+        },
         { type: 'separator' },
         { role: 'cut' },
         { role: 'copy' },

--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
     "redux": "^4.0.0",
     "redux-devtools-extension": "^2.13.5",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "redux-undo": "^1.0.1"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.3.3",

--- a/src/actionTypes/index.ts
+++ b/src/actionTypes/index.ts
@@ -32,3 +32,5 @@ export const DELETE_IMAGE: string = 'DELETE_IMAGE';
 export const TOGGLE_STATE: string = 'TOGGLE_STATE';
 export const TOGGLE_CLASS: string = 'TOGGLE_CLASS';
 export const CHANGE_TUTORIAL: string = 'CHANGE_TUTORIAL';
+export const UNDO: string = 'UNDO';
+export const REDO: string = 'REDO';

--- a/src/actions/components.ts
+++ b/src/actions/components.ts
@@ -34,6 +34,8 @@ import {
   CHANGE_IMAGE_SOURCE,
   DELETE_IMAGE,
   CHANGE_TUTORIAL,
+  UNDO,
+  REDO
 } from '../actionTypes/index';
 
 import { loadState } from '../localStorage'; //this is a warning from 'localStorage' being a .js file instead of .ts. Convert to .ts to remove this warning.
@@ -298,6 +300,9 @@ export const updateHtmlAttr = ({
     payload: { attr, value },
   });
 };
+
+
+
 
 //Action reserved for SortChildren component not written yet
 // export const updateChildrenSort = ({ newSortValues }: { newSortValues: any }) => (

--- a/src/actions/components.ts
+++ b/src/actions/components.ts
@@ -35,7 +35,7 @@ import {
   DELETE_IMAGE,
   CHANGE_TUTORIAL,
   UNDO,
-  REDO
+  REDO,
 } from '../actionTypes/index';
 
 import { loadState } from '../localStorage'; //this is a warning from 'localStorage' being a .js file instead of .ts. Convert to .ts to remove this warning.
@@ -57,14 +57,16 @@ export const loadInitData = () => (dispatch: (arg: Action) => void) => {
     dispatch({
       type: LOAD_INIT_DATA,
       payload: {
-        data: data ? data.workspace : {},
+        data: data
+          ? { ...data.workspace, history: [], historyIndex: 0, future: [] } //erase history upon opening app
+          : {},
       },
     });
   });
 };
 
 export const addComponent = ({ title }: { title: string }) => (
-  dispatch: (arg: Action) => void,
+  dispatch: (arg: Action) => void
 ) => {
   dispatch({ type: ADD_COMPONENT, payload: { title } });
 };
@@ -116,14 +118,14 @@ export const deleteComponent = ({
 };
 
 export const changeFocusComponent = ({ title }: { title: string }) => (
-  dispatch: (arg: Action) => void,
+  dispatch: (arg: Action) => void
 ) => {
   dispatch({ type: CHANGE_FOCUS_COMPONENT, payload: { title } });
 };
 
 // make sure childId is being sent in
 export const changeFocusChild = ({ childId }: { childId: number }) => (
-  dispatch: (arg: Action) => void,
+  dispatch: (arg: Action) => void
 ) => {
   dispatch({ type: CHANGE_FOCUS_CHILD, payload: { childId } });
 };
@@ -165,13 +167,13 @@ export const exportFiles = ({
       dispatch({
         type: EXPORT_FILES_SUCCESS,
         payload: { status: true, dir: dir[0] },
-      }),
+      })
     )
     .catch((err: string) =>
       dispatch({
         type: EXPORT_FILES_ERROR,
         payload: { status: true, err },
-      }),
+      })
     );
 };
 
@@ -188,7 +190,7 @@ export const handleTransform = (
     y,
     width,
     height,
-  }: { x: number; y: number; width: number; height: number },
+  }: { x: number; y: number; width: number; height: number }
 ) => ({
   type: HANDLE_TRANSFORM,
   payload: {
@@ -222,7 +224,7 @@ export const createApplication = ({
         path,
         components,
         exportAppBool,
-      }),
+      })
     );
   } else if (genOption) {
     exportAppBool = true;
@@ -244,14 +246,14 @@ export const createApplication = ({
             path,
             components,
             exportAppBool,
-          }),
+          })
         );
       })
       .catch((err: string) =>
         dispatch({
           type: CREATE_APPLICATION_ERROR,
           payload: { status: true, err },
-        }),
+        })
       );
   }
 };
@@ -266,19 +268,19 @@ export const deleteAllData = () => ({
 });
 
 export const deleteProp = (propId: number) => (
-  dispatch: (arg: Action) => void,
+  dispatch: (arg: Action) => void
 ) => {
   dispatch({ type: DELETE_PROP, payload: propId });
 };
 
 export const toggleComponentState = (id: string) => (
-  dispatch: (arg: Action) => void,
+  dispatch: (arg: Action) => void
 ) => {
   dispatch({ type: TOGGLE_STATE, payload: id });
 };
 
 export const toggleComponentClass = (id: string) => (
-  dispatch: (arg: Action) => void,
+  dispatch: (arg: Action) => void
 ) => {
   dispatch({ type: TOGGLE_CLASS, payload: id });
 };
@@ -286,6 +288,16 @@ export const toggleComponentClass = (id: string) => (
 export const addProp = (prop: PropInt) => ({
   type: ADD_PROP,
   payload: { ...prop },
+});
+
+
+//action creators for undo and redo
+export const undo = () => ({
+  type: UNDO,
+});
+
+export const redo = () => ({
+  type: REDO,
 });
 
 export const updateHtmlAttr = ({
@@ -300,9 +312,6 @@ export const updateHtmlAttr = ({
     payload: { attr, value },
   });
 };
-
-
-
 
 //Action reserved for SortChildren component not written yet
 // export const updateChildrenSort = ({ newSortValues }: { newSortValues: any }) => (

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -72,10 +72,6 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
       <Grid item xs={9}>
         <div
           className={classes.root}
-          style={
-            // shadow to highlight the focused component card
-            focusedToggle ? { boxShadow: '4px 4px 4px rgba(0, 0, 0, .4)' } : {}
-          }
         >
           {/* {This is the component responsible for the collapsing transition animation for each component card} */}
           <Collapse

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -80,7 +80,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
           <Collapse
             in={focusedToggle}
             collapsedHeight={'70px'}
-            timeout={500} //The type for the Collapse component is asking for a string, but if you put in a string and not a number, the component itself breaks.
+            timeout={750} 
           >
             {/* NOT SURE WHY COLOR: RED IS USED, TRIED REMOVING IT AND NO VISIBLE CHANGE OCCURED. */}
             <Grid

--- a/src/components/Props.tsx
+++ b/src/components/Props.tsx
@@ -110,7 +110,7 @@ const styles = (theme: any) => ({
   },
   dataTable: {
     border: '1px solid red',
-    backgroundColor: 'red'
+    backgroundColor: 'red',
     width: '60%',
   },
   light: {

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -197,7 +197,7 @@ class Tutorial extends Component<Props> {
         closeAfterTransition
         BackdropComponent={Backdrop}
         BackdropProps={{
-          timeout: 500,
+          timeout: {enter: 500, exit: 500},
         }}
         style={{
           display: 'grid',

--- a/src/containers/AppContainer.tsx
+++ b/src/containers/AppContainer.tsx
@@ -29,6 +29,8 @@ interface Props {
   loadInitData(): void;
   changeImagePath(imageSource: string): void;
   changeTutorial(tutorial: number): void;
+  undo(): void;
+  redo(): void;
   tutorial: number;
 }
 
@@ -100,8 +102,13 @@ class AppContainer extends Component<Props, State> {
 
     //Undo command listener
     IPC.on('undo', () => {
-      console.log('undo');
+
     });
+
+        //Redo command listener
+        IPC.on('redo', () => {
+
+        });
   }
 
   handleNext = (tutorial: number) => {

--- a/src/containers/AppContainer.tsx
+++ b/src/containers/AppContainer.tsx
@@ -82,7 +82,7 @@ class AppContainer extends Component<Props, State> {
     //it changes the imagesource in the global state to be whatever filepath it is
     //on the user's comp.
 
-    //TODO Fix event typing?
+    //New File command listener
     IPC.on('new-file', (event: string, file: string) => {
       const image = new window.Image();
       image.src = file;
@@ -92,8 +92,15 @@ class AppContainer extends Component<Props, State> {
         this.setState({ image, changed: true });
       };
     });
+
+    //Tutorial command listener
     IPC.on('tutorial_clicked', () => {
       this.props.changeTutorial(1);
+    });
+
+    //Undo command listener
+    IPC.on('undo', () => {
+      console.log('undo');
     });
   }
 

--- a/src/containers/AppContainer.tsx
+++ b/src/containers/AppContainer.tsx
@@ -65,6 +65,8 @@ const mapDispatchToProps = (dispatch: (arg: any) => void) => ({
   //function to change the tutorial step
   changeTutorial: (tutorial: number) =>
     dispatch(actions.changeTutorial(tutorial)),
+  undo: () => dispatch(actions.undo()),
+  redo: () => dispatch(actions.redo()),
 });
 
 class AppContainer extends Component<Props, State> {
@@ -102,13 +104,13 @@ class AppContainer extends Component<Props, State> {
 
     //Undo command listener
     IPC.on('undo', () => {
-
+      this.props.undo();
     });
 
-        //Redo command listener
-        IPC.on('redo', () => {
-
-        });
+    //Redo command listener
+    IPC.on('redo', () => {
+      this.props.redo();
+    });
   }
 
   handleNext = (tutorial: number) => {

--- a/src/reducers/componentReducer.ts
+++ b/src/reducers/componentReducer.ts
@@ -33,6 +33,8 @@ import {
   DELETE_PROP,
   UPDATE_HTML_ATTR,
   UPDATE_CHILDREN_SORT,
+  UNDO,
+  REDO,
 } from '../actionTypes/index';
 
 import {
@@ -57,6 +59,8 @@ import {
   updateChildrenSort,
   toggleComponentState,
   toggleComponentClass,
+  undo,
+  redo
 } from '../utils/componentReducer.util';
 import cloneDeep from '../utils/cloneDeep';
 

--- a/src/reducers/componentReducer.ts
+++ b/src/reducers/componentReducer.ts
@@ -115,6 +115,9 @@ const initialApplicationState: ApplicationStateInt = {
   components: [appComponent],
   appDir: '',
   loading: false,
+  history: [],
+  historyIndex: 0,
+  future: []
 };
 
 const componentReducer = (state = initialApplicationState, action: Action) => {
@@ -175,6 +178,10 @@ const componentReducer = (state = initialApplicationState, action: Action) => {
       return updateHtmlAttr(state, action.payload);
     case UPDATE_CHILDREN_SORT:
       return updateChildrenSort(state, action.payload);
+      case UNDO:
+        return undo(state);
+        case REDO:
+          return redo(state);
     default:
       return state;
   }

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -76,13 +76,12 @@ export interface ApplicationStateInt {
   components: ComponentsInt;
   appDir: string;
   loading: boolean;
-  history?: History;
+  history: ApplicationStateInt[];
+  historyIndex: number;
+  future: ApplicationStateInt[];
 }
 
-export interface History {
-  value: ApplicationStateInt;
-  next: History;
-}
+
 
 //Global Action interface \
 export interface Action {

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -76,6 +76,12 @@ export interface ApplicationStateInt {
   components: ComponentsInt;
   appDir: string;
   loading: boolean;
+  history?: History;
+}
+
+export interface History {
+  value: ApplicationStateInt;
+  next: History;
 }
 
 //Global Action interface \

--- a/src/utils/componentReducer.util.ts
+++ b/src/utils/componentReducer.util.ts
@@ -36,6 +36,7 @@ export const addComponent = (
   state: ApplicationStateInt,
   { title }: { title: string },
 ) => {
+
   // remove whitespace and digits, capitalize first char
   const strippedTitle = title
     .replace(/[a-z]+/gi, word => word[0].toUpperCase() + word.slice(1))
@@ -63,10 +64,8 @@ export const addComponent = (
   //chooses a color for the component from the random color generator
   let componentColor = getColor();
   //Makes sure no two consecutive components have the same color
-  const lastColor = state.components.find(
-    element => element.id === state.nextId - 1,
-  ).color;
-  while (componentColor === lastColor) {
+  const lastComponent = state.components.reduce((acc, curr) => curr.id > acc.id ? curr : acc).color;
+  while (componentColor === lastComponent) {
     componentColor = getColor();
   }
   //assigns the componentID to whatever issupposed to be next
@@ -98,6 +97,7 @@ export const addComponent = (
   // reset focused child to null values so when focused component is assigned to the newly created component,
   //child from previously focused component doesn;t show up
   const newFocusChild = cloneDeep(state.initialApplicationFocusChild);
+
   return {
     ...state,
     totalComponents,
@@ -107,6 +107,7 @@ export const addComponent = (
     focusChild: newFocusChild,
     ancestors,
     selectableChildren, // new component so everyone except yourself is available
+
   };
 };
 
@@ -221,6 +222,7 @@ export const addChild = (
     components,
     focusChild: newChild,
     focusComponent: component, // refresh the focus component so we have the new child
+
   };
 };
 
@@ -274,6 +276,7 @@ export const deleteChild = (
     parentComponentCopy,
   ];
 
+
   return {
     ...state,
     components: modifiedComponentArray,
@@ -285,6 +288,7 @@ export const deleteChild = (
       : parentComponentCopy.childrenArray[
           parentComponentCopy.childrenArray.length - 1
         ] || cloneDeep(state.initialApplicationFocusChild), // guard in case final child is deleted
+
   };
 };
 
@@ -293,9 +297,11 @@ export const deleteChild = (
 //since currently HTML image lives in a local state of AppContainer ( a big no-no)
 //and if a user clicks on 'clear workspace', the button doesn't reset
 export const deleteImage = (state: ApplicationStateInt) => {
+
   return {
     ...state,
     imageSource: '',
+
   };
 };
 
@@ -391,6 +397,7 @@ export const handleTransform = (
     ...state,
     components,
     focusChild: newFocusChild,
+
   };
 };
 
@@ -410,9 +417,11 @@ export const changeImageSource = (
   state: ApplicationStateInt,
   { imageSource }: { imageSource: string },
 ) => {
+
   return {
     ...state,
     imageSource,
+
   };
 };
 
@@ -460,6 +469,7 @@ export const deleteComponent = (
     ...state,
     totalComponents,
     components: componentsCopy,
+
   };
 };
 
@@ -478,9 +488,11 @@ export const toggleComponentState = (
     }
   });
   // return state and updated components array
+
   return {
     ...state,
     components: componentCopy,
+
   };
 };
 
@@ -499,9 +511,11 @@ export const toggleComponentClass = (
     }
   });
   // return state and updated components array
+
   return {
     ...state,
     components: componentCopy,
+
   };
 };
 
@@ -665,10 +679,17 @@ export const addProp = (
     (comp: ComponentInt) => comp.id !== selectedComponent.id,
   );
   newComponents.push(modifiedComponent);
+  const currentState = cloneDeep(state);
+  const stateMemory = [...state.stateMemory, currentState];
+  const memoryIndex = state.memoryIndex + 1;
+  const redoMemory: [] = [];
   return {
     ...state,
     components: newComponents,
     focusComponent: modifiedComponent,
+    stateMemory,
+    memoryIndex,
+    redoMemory
   };
 };
 
@@ -700,11 +721,17 @@ export const deleteProp = (state: ApplicationStateInt, propId: number) => {
     (comp: ComponentInt) => comp.id !== modifiedComponent.id,
   );
   newComponentsArray.push(modifiedComponent);
-
+  const currentState = cloneDeep(state);
+  const stateMemory = [...state.stateMemory, currentState];
+  const memoryIndex = state.memoryIndex + 1;
+  const redoMemory: [] = [];
   return {
     ...state,
     components: newComponentsArray,
     focusComponent: modifiedComponent,
+    stateMemory,
+    memoryIndex,
+    redoMemory
   };
 };
 
@@ -737,12 +764,18 @@ export const updateHtmlAttr = (
     (comp: ComponentInt) => comp.id !== modifiedComponent.id,
   );
   newComponentsArray.push(modifiedComponent);
-
+  const currentState = cloneDeep(state);
+  const stateMemory = [...state.stateMemory, currentState];
+  const memoryIndex = state.memoryIndex + 1;
+  const redoMemory: [] = [];
   return {
     ...state,
     components: newComponentsArray,
     focusComponent: modifiedComponent,
     focusChild: modifiedChild,
+    stateMemory,
+    memoryIndex,
+    redoMemory
   };
 };
 
@@ -783,3 +816,5 @@ export const updateChildrenSort = (
     focusComponent: modifiedComponent,
   };
 };
+
+

--- a/src/utils/componentReducer.util.ts
+++ b/src/utils/componentReducer.util.ts
@@ -32,11 +32,29 @@ const initialComponentState: ComponentInt = {
   focusChildId: 0,
 };
 
+/*Helper function that copies the state to be added on to the history
+  By clearing the history data out of each stored step of the timeline,
+  you can avoid repetitive nesting that maxes out the memory allocated to electron
+  (usually happens at around 7-10 steps without using this method)*/
+const createHistory = (state: ApplicationStateInt) => {
+  const stateCopy = cloneDeep(state);
+  const historyCopy = cloneDeep(state.history);
+  historyCopy.push({ ...stateCopy, history: [] });
+  const history = historyCopy;
+  const historyIndex = state.historyIndex + 1;
+  const future: [] = [];
+
+  return {
+    history,
+    historyIndex,
+    future,
+  };
+};
+
 export const addComponent = (
   state: ApplicationStateInt,
-  { title }: { title: string },
+  { title }: { title: string }
 ) => {
-
   // remove whitespace and digits, capitalize first char
   const strippedTitle = title
     .replace(/[a-z]+/gi, word => word[0].toUpperCase() + word.slice(1))
@@ -47,7 +65,7 @@ export const addComponent = (
     state.components.find((comp: ComponentInt) => comp.title === strippedTitle)
   ) {
     window.alert(
-      `A component with the name: "${strippedTitle}" already exists.\n Please think of another name.`,
+      `A component with the name: "${strippedTitle}" already exists.\n Please think of another name.`
     );
     return {
       ...state,
@@ -64,7 +82,9 @@ export const addComponent = (
   //chooses a color for the component from the random color generator
   let componentColor = getColor();
   //Makes sure no two consecutive components have the same color
-  const lastComponent = state.components.reduce((acc, curr) => curr.id > acc.id ? curr : acc).color;
+  const lastComponent = state.components.reduce((acc, curr) =>
+    curr.id > acc.id ? curr : acc
+  ).color;
   while (componentColor === lastComponent) {
     componentColor = getColor();
   }
@@ -98,6 +118,8 @@ export const addComponent = (
   //child from previously focused component doesn;t show up
   const newFocusChild = cloneDeep(state.initialApplicationFocusChild);
 
+  const { history, historyIndex, future } = createHistory(state);
+
   return {
     ...state,
     totalComponents,
@@ -107,7 +129,9 @@ export const addComponent = (
     focusChild: newFocusChild,
     ancestors,
     selectableChildren, // new component so everyone except yourself is available
-
+    history,
+    historyIndex,
+    future,
   };
 };
 
@@ -122,7 +146,7 @@ export const addChild = (
     title: string;
     childType: string;
     HTMLInfo: { [index: string]: string };
-  },
+  }
 ) => {
   const strippedTitle = title;
 
@@ -140,7 +164,7 @@ export const addChild = (
   // view represents the curretn FOCUSED COMPONENT - this is the component where the child is being added to
   // we only add childrent (or do any action) to the focused omconent
   const view: ComponentInt = state.components.find(
-    (comp: ComponentInt) => comp.title === state.focusComponent.title,
+    (comp: ComponentInt) => comp.title === state.focusComponent.title
   );
 
   // parentComponent is the component this child is generated from (ex. instance of Box has comp of Box)
@@ -149,7 +173,7 @@ export const addChild = (
   // conditional if adding an HTML component
   if (childType === 'COMP') {
     parentComponent = state.components.find(
-      (comp: ComponentInt) => comp.title === title,
+      (comp: ComponentInt) => comp.title === title
     );
   }
 
@@ -166,7 +190,7 @@ export const addChild = (
     //I don't think this error does anything anymore either.
     if (!htmlElemPosition.width) {
       console.log(
-        `Did not add html child: ${htmlElement} the GetSize function indicated that it isnt in our DB`,
+        `Did not add html child: ${htmlElement} the GetSize function indicated that it isnt in our DB`
       );
       return;
     }
@@ -216,13 +240,16 @@ export const addChild = (
     }),
     component,
   ];
+  const { history, historyIndex, future } = createHistory(state);
 
   return {
     ...state,
     components,
     focusChild: newChild,
     focusComponent: component, // refresh the focus component so we have the new child
-
+    history,
+    historyIndex,
+    future,
   };
 };
 
@@ -232,7 +259,7 @@ export const deleteChild = (
     parentId = state.focusComponent.id,
     childId = state.focusChild.childId,
     calledFromDeleteComponent = false,
-  },
+  }
 ) => {
   /** ************************************************
   if no parameters are provided we default to delete the FOCUSED CHILD of the FOCUSED COMPONENTS
@@ -254,12 +281,12 @@ export const deleteChild = (
 
   // make a DEEP copy of the parent component (the one thats about to loose a child)
   const parentComponentCopy: any = cloneDeep(
-    state.components.find((comp: ComponentInt) => comp.id === parentId),
+    state.components.find((comp: ComponentInt) => comp.id === parentId)
   );
 
   // delete the CHILD from the copied array
   const indexToDelete = parentComponentCopy.childrenArray.findIndex(
-    (elem: ChildInt) => elem.childId === childId,
+    (elem: ChildInt) => elem.childId === childId
   );
   if (indexToDelete < 0) {
     return window.alert('No such child component found');
@@ -276,6 +303,7 @@ export const deleteChild = (
     parentComponentCopy,
   ];
 
+  const { history, historyIndex, future } = createHistory(state);
 
   return {
     ...state,
@@ -288,7 +316,9 @@ export const deleteChild = (
       : parentComponentCopy.childrenArray[
           parentComponentCopy.childrenArray.length - 1
         ] || cloneDeep(state.initialApplicationFocusChild), // guard in case final child is deleted
-
+    history,
+    historyIndex,
+    future,
   };
 };
 
@@ -297,11 +327,13 @@ export const deleteChild = (
 //since currently HTML image lives in a local state of AppContainer ( a big no-no)
 //and if a user clicks on 'clear workspace', the button doesn't reset
 export const deleteImage = (state: ApplicationStateInt) => {
-
+  const { history, historyIndex, future } = createHistory(state);
   return {
     ...state,
     imageSource: '',
-
+    history,
+    historyIndex,
+    future,
   };
 };
 
@@ -322,12 +354,12 @@ export const handleTransform = (
     y: number;
     width: number;
     height: number;
-  },
+  }
 ) => {
   if (childId === -1) {
     // the pseudochild has been transformed, its position is stored in the component
     const component = state.components.find(
-      (comp: ComponentInt) => comp.id === componentId,
+      (comp: ComponentInt) => comp.id === componentId
     );
 
     //first check if changed, if falsy then assign the original values
@@ -392,19 +424,22 @@ export const handleTransform = (
     }),
     component,
   ];
+  const { history, historyIndex, future } = createHistory(state);
 
   return {
     ...state,
     components,
     focusChild: newFocusChild,
-
+    history,
+    historyIndex,
+    future,
   };
 };
 
 //Change which step of the tutorial the user currently is at
 export const changeTutorial = (
   state: ApplicationStateInt,
-  { tutorial }: { tutorial: number },
+  { tutorial }: { tutorial: number }
 ) => {
   return {
     ...state,
@@ -415,28 +450,31 @@ export const changeTutorial = (
 //change image source
 export const changeImageSource = (
   state: ApplicationStateInt,
-  { imageSource }: { imageSource: string },
+  { imageSource }: { imageSource: string }
 ) => {
+  const { history, historyIndex, future } = createHistory(state);
 
   return {
     ...state,
     imageSource,
-
+    history,
+    historyIndex,
+    future,
   };
 };
 
 //Reducer that deletes the component selected
 export const deleteComponent = (
   state: ApplicationStateInt,
-  { componentId }: { componentId: number },
+  { componentId }: { componentId: number }
 ) => {
   //select the component from list of components
   const compName = state.components.filter(
-    (value: ComponentInt) => value.id === componentId,
+    (value: ComponentInt) => value.id === componentId
   );
   //confimation window to see if user really wants to delete component
   const result = window.confirm(
-    `Are you sure you want to delete ${compName[0].title}?`,
+    `Are you sure you want to delete ${compName[0].title}?`
   );
   //if cancelled, return focus to current selected component
   if (!result) {
@@ -455,7 +493,7 @@ export const deleteComponent = (
 
   //finds index of component to delete
   const indexToDelete = state.components.findIndex(
-    (comp: ComponentInt) => comp.id == componentId,
+    (comp: ComponentInt) => comp.id == componentId
   );
 
   //creates a deep copy of the components
@@ -465,18 +503,22 @@ export const deleteComponent = (
   //decrease number of components by one
   const totalComponents = state.totalComponents - 1;
 
+  const { history, historyIndex, future } = createHistory(state);
+
   return {
     ...state,
     totalComponents,
     components: componentsCopy,
-
+    history,
+    historyIndex,
+    future,
   };
 };
 
 //Reducer that toggles the component statefulness
 export const toggleComponentState = (
   state: ApplicationStateInt,
-  id: number,
+  id: number
 ) => {
   //creates a deep copy of the components array
   const componentCopy = cloneDeep(state.components);
@@ -488,18 +530,21 @@ export const toggleComponentState = (
     }
   });
   // return state and updated components array
+  const { history, historyIndex, future } = createHistory(state);
 
   return {
     ...state,
     components: componentCopy,
-
+    history,
+    historyIndex,
+    future,
   };
 };
 
 //Reducer that toggles the component class
 export const toggleComponentClass = (
   state: ApplicationStateInt,
-  id: number,
+  id: number
 ) => {
   //creates a deep copy of the components array
   const componentCopy = cloneDeep(state.components);
@@ -511,24 +556,27 @@ export const toggleComponentClass = (
     }
   });
   // return state and updated components array
+  const { history, historyIndex, future } = createHistory(state);
 
   return {
     ...state,
     components: componentCopy,
-
+    history,
+    historyIndex,
+    future,
   };
 };
 
 export const changeFocusComponent = (
   state: ApplicationStateInt,
-  { title = state.focusComponent.title }: { title: string },
+  { title = state.focusComponent.title }: { title: string }
 ) => {
   /** ****************
    * if the prm TITLE is a blank Object it means REFRESH focusd Components.
    * sometimes we update state  like adding Children/Props etc and we want those changes to be reflected in focus component
    ************************************************* */
   const newFocusComp: ComponentInt = state.components.find(
-    (comp: ComponentInt) => comp.title === title,
+    (comp: ComponentInt) => comp.title === title
   );
 
   // set the "focus child" to the focus child of this particular component .
@@ -536,7 +584,7 @@ export const changeFocusComponent = (
   let newFocusChild: ChildInt | any; // check if the components has a child saved as a Focus child
   if (newFocusComp.focusChildId > 0) {
     newFocusChild = newFocusComp.childrenArray.find(
-      (child: ChildInt) => child.childId === newFocusComp.focusChildId,
+      (child: ChildInt) => child.childId === newFocusComp.focusChildId
     );
   }
 
@@ -557,13 +605,13 @@ export const changeFocusComponent = (
 
 export const changeFocusChild = (
   state: ApplicationStateInt,
-  { childId }: { childId: number },
+  { childId }: { childId: number }
 ) => {
   const focComp = state.components.find(
-    (comp: ComponentInt) => comp.title === state.focusComponent.title,
+    (comp: ComponentInt) => comp.title === state.focusComponent.title
   );
   let newFocusChild: ChildInt = focComp.childrenArray.find(
-    (child: ChildInt) => child.childId === childId,
+    (child: ChildInt) => child.childId === childId
   );
 
   if (!newFocusChild) {
@@ -593,15 +641,15 @@ export const changeFocusChild = (
 
 export const changeComponentFocusChild = (
   state: ApplicationStateInt,
-  { componentId, childId }: { componentId: number; childId: number },
+  { componentId, childId }: { componentId: number; childId: number }
 ) => {
   const component: ComponentInt = state.components.find(
-    comp => comp.id === componentId,
+    comp => comp.id === componentId
   );
   const modifiedComponent: any = cloneDeep(component);
   modifiedComponent.focusChildId = childId;
   const components: ComponentsInt = state.components.filter(
-    comp => comp.id !== componentId,
+    comp => comp.id !== componentId
   );
   return {
     ...state,
@@ -611,7 +659,7 @@ export const changeComponentFocusChild = (
 
 export const exportFilesSuccess = (
   state: ApplicationStateInt,
-  { status, dir }: { status: boolean; dir: string },
+  { status, dir }: { status: boolean; dir: string }
 ) => ({
   ...state,
   successOpen: status,
@@ -621,7 +669,7 @@ export const exportFilesSuccess = (
 
 export const exportFilesError = (
   state: ApplicationStateInt,
-  { status, err }: { status: boolean; err: string },
+  { status, err }: { status: boolean; err: string }
 ) => ({
   ...state,
   errorOpen: status,
@@ -637,7 +685,7 @@ export const handleClose = (state: ApplicationStateInt, status: string) => ({
 
 export const openExpansionPanel = (
   state: ApplicationStateInt,
-  { component }: { component: ComponentInt },
+  { component }: { component: ComponentInt }
 ) => ({
   ...state,
 });
@@ -649,7 +697,7 @@ export const addProp = (
     value = null,
     required,
     type,
-  }: { key: string; value: string; required: boolean; type: string },
+  }: { key: string; value: string; required: boolean; type: string }
 ) => {
   if (!state.focusComponent.id) {
     console.log('Add prop error. no focused component ');
@@ -657,7 +705,7 @@ export const addProp = (
   }
 
   const selectedComponent = state.components.find(
-    (comp: ComponentInt) => comp.id === state.focusComponent.id,
+    (comp: ComponentInt) => comp.id === state.focusComponent.id
   );
 
   const newProp: PropInt = {
@@ -676,20 +724,18 @@ export const addProp = (
   };
 
   const newComponents: ComponentsInt = state.components.filter(
-    (comp: ComponentInt) => comp.id !== selectedComponent.id,
+    (comp: ComponentInt) => comp.id !== selectedComponent.id
   );
   newComponents.push(modifiedComponent);
-  const currentState = cloneDeep(state);
-  const stateMemory = [...state.stateMemory, currentState];
-  const memoryIndex = state.memoryIndex + 1;
-  const redoMemory: [] = [];
+  const { history, historyIndex, future } = createHistory(state);
+
   return {
     ...state,
     components: newComponents,
     focusComponent: modifiedComponent,
-    stateMemory,
-    memoryIndex,
-    redoMemory
+    historyIndex,
+    history,
+    future,
   };
 };
 
@@ -701,16 +747,16 @@ export const deleteProp = (state: ApplicationStateInt, propId: number) => {
 
   const modifiedComponent: any = cloneDeep(
     state.components.find(
-      (comp: ComponentInt) => comp.id === state.focusComponent.id,
-    ),
+      (comp: ComponentInt) => comp.id === state.focusComponent.id
+    )
   );
 
   const indexToDelete = modifiedComponent.props.findIndex(
-    (prop: PropInt) => prop.id === propId,
+    (prop: PropInt) => prop.id === propId
   );
   if (indexToDelete === -1) {
     console.log(
-      `Delete prop Error. Prop id:${propId} not found in ${modifiedComponent.title}`,
+      `Delete prop Error. Prop id:${propId} not found in ${modifiedComponent.title}`
     );
     return state;
   }
@@ -718,26 +764,24 @@ export const deleteProp = (state: ApplicationStateInt, propId: number) => {
   modifiedComponent.props.splice(indexToDelete, 1);
 
   const newComponentsArray = state.components.filter(
-    (comp: ComponentInt) => comp.id !== modifiedComponent.id,
+    (comp: ComponentInt) => comp.id !== modifiedComponent.id
   );
   newComponentsArray.push(modifiedComponent);
-  const currentState = cloneDeep(state);
-  const stateMemory = [...state.stateMemory, currentState];
-  const memoryIndex = state.memoryIndex + 1;
-  const redoMemory: [] = [];
+  const { history, historyIndex, future } = createHistory(state);
+
   return {
     ...state,
     components: newComponentsArray,
     focusComponent: modifiedComponent,
-    stateMemory,
-    memoryIndex,
-    redoMemory
+    history,
+    historyIndex,
+    future,
   };
 };
 
 export const updateHtmlAttr = (
   state: ApplicationStateInt,
-  { attr, value }: { attr: string; value: string },
+  { attr, value }: { attr: string; value: string }
 ) => {
   if (!state.focusChild.childId) {
     console.log('Update HTML error. no focused child ');
@@ -750,63 +794,61 @@ export const updateHtmlAttr = (
   const modifiedComponent: ComponentInt = JSON.parse(
     JSON.stringify(
       state.components.find(
-        (comp: ComponentInt) => comp.id === state.focusComponent.id,
-      ),
-    ),
+        (comp: ComponentInt) => comp.id === state.focusComponent.id
+      )
+    )
   );
 
   modifiedComponent.childrenArray = modifiedComponent.childrenArray.filter(
-    (child: ChildInt) => child.childId !== modifiedChild.childId,
+    (child: ChildInt) => child.childId !== modifiedChild.childId
   );
   modifiedComponent.childrenArray.push(modifiedChild);
 
   const newComponentsArray = state.components.filter(
-    (comp: ComponentInt) => comp.id !== modifiedComponent.id,
+    (comp: ComponentInt) => comp.id !== modifiedComponent.id
   );
   newComponentsArray.push(modifiedComponent);
-  const currentState = cloneDeep(state);
-  const stateMemory = [...state.stateMemory, currentState];
-  const memoryIndex = state.memoryIndex + 1;
-  const redoMemory: [] = [];
+  const { history, historyIndex, future } = createHistory(state);
+
   return {
     ...state,
     components: newComponentsArray,
     focusComponent: modifiedComponent,
     focusChild: modifiedChild,
-    stateMemory,
-    memoryIndex,
-    redoMemory
+    history,
+    historyIndex,
+    future,
   };
 };
 
 export const updateChildrenSort = (
   state: ApplicationStateInt,
-  { newSortValues }: { newSortValues: any },
+  { newSortValues }: { newSortValues: any }
 ) => {
   const modifiedChildrenArray: any = cloneDeep(
-    state.focusComponent.childrenArray,
+    state.focusComponent.childrenArray
   );
 
   for (let i = 0; i < modifiedChildrenArray.length; i += 1) {
     const currChild = modifiedChildrenArray[i];
     const currChildId = currChild.childId;
     const newValueObj = newSortValues.find(
-      (n: any) => n.childId === currChildId,
+      (n: any) => n.childId === currChildId
     );
     const newSortValue = newValueObj.childSort;
     console.log(
-      ` currChildId  ${currChildId} currSortValue: ${currChild.childSort} newSortValue:${newSortValue}`,
+      ` currChildId  ${currChildId} currSortValue: ${currChild.childSort} newSortValue:${newSortValue}`
     );
     currChild.childSort = newSortValue;
   }
 
   const modifiedComponent = state.components.find(
-    (comp: ComponentInt) => comp.id === state.focusComponent.id,
+    (comp: ComponentInt) => comp.id === state.focusComponent.id
   );
   modifiedComponent.childrenArray = modifiedChildrenArray;
 
   const modifiedComponentsArray = state.components.filter(
-    (comp: ComponentInt) => comp.id !== state.focusComponent.id,
+    (comp: ComponentInt) => comp.id !== state.focusComponent.id
   );
   modifiedComponentsArray.push(modifiedComponent);
 
@@ -817,4 +859,42 @@ export const updateChildrenSort = (
   };
 };
 
+export const undo = (state: ApplicationStateInt) => {
+  //return current state if there is no history
+  if (!state.historyIndex) return { ...state };
+  const stateCopy = cloneDeep(state);
+  const futureCopy = cloneDeep(state.future);
+  const historyCopy = cloneDeep(state.history);
+  //remove last element of history to assign it to the 'undone' state on the 'undoData' varaiable below
+  historyCopy.pop();
+  const history = historyCopy;
+  //create a new element for the 'redo' history array
+  futureCopy.unshift({ ...stateCopy, history: [] });
+  const future = futureCopy;
+  const undoData = state.history[state.historyIndex - 1];
+  return {
+    ...undoData,
+    history,
+    future,
+  };
+};
 
+export const redo = (state: ApplicationStateInt) => {
+  //if the future history array is empty, return the current state
+  if (!state.future) return { ...state };
+  const stateCopy = cloneDeep(state);
+  const futureCopy = cloneDeep(state.future);
+  //grab the first element of the future history array and assign it to the new state
+  //the rest of this is mostly the same logic as 'undo' but flipped
+  futureCopy.shift();
+  const future = futureCopy;
+  const historyCopy = cloneDeep(state.history);
+  historyCopy.push({ ...stateCopy, history: [] });
+  const history = historyCopy;
+  const redoData = state.future[0];
+  return {
+    ...redoData,
+    history,
+    future,
+  };
+};


### PR DESCRIPTION
**Problem**: Undo/Redo default functionality had no effect

**Solution**: Override the default behavior of undo/redo and specifically cater it for actions within the redux application

**Updates**

- Allow specific actions (Add Component, Add Child, Delete Child, Delete Image, Handle Transform, Change Image Source, Delete Component, Toggle Component State/Class, Add/Delete Prop, and Update HTML Attribute) to be undone and redone

- Redo history is erased each time one of the specified actions above are fired, while the undo history stays. 

- Undo/Redo history reset every time application is opened

- Undo/Redo logic avoids reaching memory capacity by storing history data only at the current state. The 'history' property of the global state is an empty array for each snapshot of the state except for the current state the user is handling. Without doing this, after around 10 steps the application will freeze up due to too many nested history arrays existing.

- Undo/Redo can be accessed via window menu, or by pressing 'Ctrl+Z(Undo)/Ctrl+Shift+Z(Redo)'. Replace Ctrl for Cmd for macs. 

**Bug Fixes**

- Fixed a bug in component card color selection that causes the app to crash when a card at the very end is deleted, and then a new card is added 