### PR TITLE
Added functionality to edit component name

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,8 @@ const {
   Menu,
   shell,
   dialog,
-  ipcMain
+  ipcMain,
+  globalShortcut
 } = require('electron');
 
 // Uncomment below for hot reloading during development
@@ -39,6 +40,10 @@ function openFile() {
 
   // Send fileContent to renderer
   mainWindow.webContents.send('new-file', file);
+}
+
+function escape() {
+  mainWindow.webContents.send('escape');
 }
 
 //functions to replace the default behavior of undo and redo
@@ -262,6 +267,9 @@ app.on('ready', () => {
   } else {
     createWindow();
   }
+  globalShortcut.register('Escape', () => {
+    escape();
+  })
 });
 
 // Quit when all windows are closed.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "cli-spinner": "^0.2.8",
     "commander": "^2.17.1",
     "concurrently": "^5.1.0",
+    "csstype": "^2.6.9",
     "d3": "^5.9.2",
     "electron-reload": "^1.4.0",
     "enzyme": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@material-ui/core": "^4.0.1",
     "@material-ui/icons": "^4.0.1",
-    "@material-ui/styles": "^4.9.0",
+    "@material-ui/styles": "^4.9.6",
     "@types/prettier": "^1.19.0",
     "@types/react": "^16.8.14",
     "@types/react-dom": "^16.8.4",
@@ -129,7 +129,6 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.3.3",
-    "@material-ui/styles": "^4.9.6",
     "awesome-typescript-loader": "^5.2.1",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.6",

--- a/src/actionTypes/index.ts
+++ b/src/actionTypes/index.ts
@@ -34,3 +34,5 @@ export const TOGGLE_CLASS: string = 'TOGGLE_CLASS';
 export const CHANGE_TUTORIAL: string = 'CHANGE_TUTORIAL';
 export const UNDO: string = 'UNDO';
 export const REDO: string = 'REDO';
+export const EDIT_MODE: string = 'EDIT_MODE';
+export const EDIT_COMPONENT: string = 'EDIT_COMPONENT';

--- a/src/actions/components.ts
+++ b/src/actions/components.ts
@@ -273,23 +273,22 @@ export const deleteProp = (propId: number) => (
   dispatch({ type: DELETE_PROP, payload: propId });
 };
 
-export const toggleComponentState = (id: string) => (
+export const toggleComponentState = ({ id }: { id: number }) => (
   dispatch: (arg: Action) => void
 ) => {
-  dispatch({ type: TOGGLE_STATE, payload: id });
+  dispatch({ type: TOGGLE_STATE, payload: { id } });
 };
 
-export const toggleComponentClass = (id: string) => (
+export const toggleComponentClass = ({ id }: { id: number }) => (
   dispatch: (arg: Action) => void
 ) => {
-  dispatch({ type: TOGGLE_CLASS, payload: id });
+  dispatch({ type: TOGGLE_CLASS, payload: { id } });
 };
 
 export const addProp = (prop: PropInt) => ({
   type: ADD_PROP,
   payload: { ...prop },
 });
-
 
 //action creators for undo and redo
 export const undo = () => ({

--- a/src/actions/components.ts
+++ b/src/actions/components.ts
@@ -36,6 +36,8 @@ import {
   CHANGE_TUTORIAL,
   UNDO,
   REDO,
+  EDIT_MODE,
+  EDIT_COMPONENT
 } from '../actionTypes/index';
 
 import { loadState } from '../localStorage'; //this is a warning from 'localStorage' being a .js file instead of .ts. Convert to .ts to remove this warning.
@@ -298,6 +300,19 @@ export const undo = () => ({
 export const redo = () => ({
   type: REDO,
 });
+
+export const toggleEditMode = ({ id }: { id: number }) => (
+  dispatch: (arg: Action) => void
+) => {
+  dispatch({ type: EDIT_MODE, payload: { id } });
+};
+
+export const editComponent = ({ id, title }: { id: number, title: string }) => (
+  dispatch: (arg: Action) => void
+) => {
+  dispatch({ type: EDIT_COMPONENT , payload: { id, title } });
+};
+ 
 
 export const updateHtmlAttr = ({
   attr,

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -144,7 +144,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                               checked={stateful}
                               onChange={e => {
                                 toggleComponentState(id);
-                                changeFocusComponent({ title });
+                                // changeFocusComponent({ title });
                               }}
                               value='stateful'
                               color='primary'
@@ -168,7 +168,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                               checked={classBased}
                               onChange={e => {
                                 toggleComponentClass(id);
-                                changeFocusComponent({ title });
+                                // changeFocusComponent({ title });
                               }}
                               value='classBased'
                               color='primary'

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import TextField from '@material-ui/core/TextField';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -25,8 +26,12 @@ interface LeftColExpPanPropsInt extends PropsInt {
     componentId: number;
     stateComponents: ComponentsInt;
   }): void;
-  toggleComponentState(arg: {id: number}): void;
-  toggleComponentClass(arg: {id: number}): void;
+  toggleComponentState(arg: { id: number }): void;
+  toggleComponentClass(arg: { id: number }): void;
+  editMode: number;
+  toggleEditMode(arg: { id: number }): void;
+  handleChangeName(event: string): void;
+  handleEditComponent(): void;
 }
 //interface created but never used
 // interface TypographyProps {
@@ -44,7 +49,11 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
     selectableChildren,
     deleteComponent,
     toggleComponentState,
-    toggleComponentClass
+    toggleComponentClass,
+    editMode,
+    toggleEditMode,
+    handleChangeName,
+    handleEditComponent,
   } = props;
   const { title, id, color, stateful, classBased } = component;
   function isFocused() {
@@ -53,14 +62,23 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
   // boolean flag to determine if the component card is focused or not
   // state/class toggles will be displayed when a component is focused
   const focusedToggle = isFocused() === 'focused' ? true : false;
+
+  const handleEdit = () => {
+    if (editMode !== id) {
+      handleChangeName(title);
+      toggleEditMode({ id });
+    } else {
+      toggleEditMode({ id: -1 });
+    }
+  };
   return (
     <Grid
       container
-      direction='row'
-      justify='center'
-      alignItems='center'
+      direction="row"
+      justify="center"
+      alignItems="center"
       style={{
-        minWidth: '470px'
+        minWidth: '470px',
       }}
     >
       <Grid item xs={9}>
@@ -71,7 +89,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
             focusedToggle
               ? {
                   boxShadow: '4px 4px 4px rgba(0, 0, 0, .4)',
-                  borderRadius: '8px'
+                  borderRadius: '8px',
                 }
               : {}
           }
@@ -93,32 +111,70 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                 backgroundColor: 'none',
                 borderRadius: '10px',
                 minWidth: '340px',
-                border: `2px solid ${color}`
+                border: `2px solid ${color}`,
               }}
             >
-              <List style={{ color: 'red' }}>
+              <List
+                style={
+                  {
+                    // color: 'red'
+                  }
+                }
+              >
                 <ListItem
                   // button // commented out to disable materialUI hover shading effect. TBD if any adverse effects occur
-                  style={{ color: 'red' }}
+                  // style={{ color: 'red' }}
                   onClick={() => {
-                    changeFocusComponent({ title });
+                    if (focusComponent.title !== title)
+                      changeFocusComponent({ title });
                   }}
                 >
                   <ListItemText
-                    disableTypography
-                    className={classes.light}
+                    // disableTypography
+                    // className={classes.light}
                     primary={
                       <div>
-                        <Typography
-                          //type='body2'
-                          style={{
-                            color: '#fff',
-                            textShadow: '1px 1px 2px rgba(0, 0, 0, 0.7)',
-                            fontSize: '1.40rem'
-                          }}
-                        >
-                          {title}
-                        </Typography>
+                        {editMode !== id ? (
+                          <Typography
+                            //type='body2'
+                            onDoubleClick={() => handleEdit()}
+                            style={{
+                              color: '#fff',
+                              textShadow: '1px 1px 2px rgba(0, 0, 0, 0.7)',
+                              fontSize: '1.40rem',
+                            }}
+                          >
+                            {title}
+                          </Typography>
+                        ) : (
+                          <TextField
+                            id="filled"
+                            label="Change Component Name"
+                            defaultValue={title}
+                            variant="outlined"
+                            className={classes.text}
+                            InputProps={{
+                              className: classes.light,
+                            }}
+                            InputLabelProps={{
+                              className: classes.inputLabel,
+                            }}
+                            autoFocus
+                            onChange={e => handleChangeName(e.target.value)}
+                            onKeyPress={ev => {
+                              if (ev.key === 'Enter') {
+                                handleEditComponent();
+                                ev.preventDefault();
+                              }
+                            }}
+                            onKeyUp={ev => {
+                              if (ev.keyCode === 27) {
+                                handleEdit();
+                                ev.preventDefault();
+                              }
+                            }}
+                          />
+                        )}
                         {/* ALL OF THE STATE/CLASS TOGGLES AND LABELS ARE ONLY RENDERED IF THEIR COMPONENT IS THE FOCUSED COMPONENT 
                         TO DO : IMPROVE DRYNESS OF CODE BY RENDERING ALL FOUR MATERIAL ELEMENTS (LABELS/SWITCH) IN ONE CONDITIONAL
                       */}
@@ -126,7 +182,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                         {focusedToggle ? (
                           <span style={{ display: 'inline-flex' }}>
                             <InputLabel
-                              htmlFor='stateful'
+                              htmlFor="stateful"
                               style={{
                                 color: '#fff',
                                 marginBottom: '0px',
@@ -134,7 +190,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                                 marginLeft: '11px',
                                 padding: '0px',
                                 fontSize: '18px',
-                                textShadow: '1px 1px 2px rgba(0, 0, 0, 0.7)'
+                                textShadow: '1px 1px 2px rgba(0, 0, 0, 0.7)',
                               }}
                             >
                               State?
@@ -145,12 +201,12 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                                 toggleComponentState({ id });
                                 changeFocusComponent({ title });
                               }}
-                              value='stateful'
-                              color='primary'
+                              value="stateful"
+                              color="primary"
                               // id={props.id.toString()}
                             />
                             <InputLabel
-                              htmlFor='classBased'
+                              htmlFor="classBased"
                               style={{
                                 color: '#fff',
                                 marginBottom: '0px',
@@ -158,7 +214,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                                 marginLeft: '11px',
                                 padding: '0px',
                                 fontSize: '18px',
-                                textShadow: '1px 1px 2px rgba(0, 0, 0, 0.7)'
+                                textShadow: '1px 1px 2px rgba(0, 0, 0, 0.7)',
                               }}
                             >
                               Class?
@@ -169,8 +225,8 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                                 toggleComponentClass({ id });
                                 changeFocusComponent({ title });
                               }}
-                              value='classBased'
-                              color='primary'
+                              value="classBased"
+                              color="primary"
                             />
                           </span>
                         ) : (
@@ -178,27 +234,27 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                         )}
                         {focusedToggle && component.id !== 1 ? (
                           <Button
-                            variant='text'
-                            size='small'
-                            color='default'
-                            aria-label='Delete'
+                            variant="text"
+                            size="small"
+                            color="default"
+                            aria-label="Delete"
                             className={classes.margin}
                             onClick={() =>
                               deleteComponent({
                                 componentId: id,
-                                stateComponents: components
+                                stateComponents: components,
                               })
                             }
                             style={{
                               color: 'white',
                               marginBottom: '0px',
-                              marginTop: '4px'
+                              marginTop: '4px',
                             }}
                           >
                             <DeleteIcon
                               style={{
                                 color: '#b30000',
-                                textShadow: '1px 1px 2px rgba(0, 0, 0, 0.5)'
+                                textShadow: '1px 1px 2px rgba(0, 0, 0, 0.5)',
                               }}
                             />
                             <div
@@ -206,7 +262,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                                 marginTop: '4px',
                                 marginLeft: '5px',
                                 fontSize: '15px',
-                                textShadow: '1px 1px 2px rgba(0, 0, 0, 0.8)'
+                                textShadow: '1px 1px 2px rgba(0, 0, 0, 0.8)',
                               }}
                             >
                               Delete Component
@@ -230,12 +286,12 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
           <div />
         ) : (
           <Tooltip
-            title='add as child'
-            aria-label='add as child'
-            placement='left'
+            title="add as child"
+            aria-label="add as child"
+            placement="left"
           >
             <IconButton
-              aria-label='Add'
+              aria-label="Add"
               onClick={() => {
                 addChild({ title, childType: 'COMP' });
               }}
@@ -253,14 +309,28 @@ function styles(): object {
     root: {
       width: '100%',
       marginTop: 10,
-      backgroundColor: '#333333'
     },
     light: {
       color: '#eee',
       '&:hover': {
-        color: '#1de9b6'
-      }
-    }
+        color: '#1de9b6',
+      },
+    },
+    inputLabel: {
+      fontSize: '16px',
+      color: '#fff',
+    },
+    text: {
+      '& .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline': {
+        borderColor: 'white',
+      },
+      '&:hover .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline': {
+        borderColor: 'white',
+      },
+      '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
+        borderColor: 'white',
+      },
+    },
   };
 }
 export default withStyles(styles)(LeftColExpansionPanel);

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -25,8 +25,8 @@ interface LeftColExpPanPropsInt extends PropsInt {
     componentId: number;
     stateComponents: ComponentsInt;
   }): void;
-  toggleComponentState(arg: number): void;
-  toggleComponentClass(arg: number): void;
+  toggleComponentState(arg: {id: number}): void;
+  toggleComponentClass(arg: {id: number}): void;
 }
 //interface created but never used
 // interface TypographyProps {
@@ -56,7 +56,6 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
   return (
     <Grid
       container
-      spacing={16}
       direction='row'
       justify='center'
       alignItems='center'
@@ -142,9 +141,9 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                             </InputLabel>
                             <Switch
                               checked={stateful}
-                              onChange={e => {
-                                toggleComponentState(id);
-                                // changeFocusComponent({ title });
+                              onChange={() => {
+                                toggleComponentState({ id });
+                                changeFocusComponent({ title });
                               }}
                               value='stateful'
                               color='primary'
@@ -166,9 +165,9 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                             </InputLabel>{' '}
                             <Switch
                               checked={classBased}
-                              onChange={e => {
-                                toggleComponentClass(id);
-                                // changeFocusComponent({ title });
+                              onChange={() => {
+                                toggleComponentClass({ id });
+                                changeFocusComponent({ title });
                               }}
                               value='classBased'
                               color='primary'
@@ -204,7 +203,8 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                             />
                             <div
                               style={{
-                                marginTop: '3px',
+                                marginTop: '4px',
+                                marginLeft: '5px',
                                 fontSize: '15px',
                                 textShadow: '1px 1px 2px rgba(0, 0, 0, 0.8)'
                               }}
@@ -217,42 +217,11 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                         )}
                       </div>
                     }
-                    // style={{ color }}
                   />
                 </ListItem>
               </List>
             </Grid>
           </Collapse>
-          {/* {id === 1 || !isFocused() ? (           Removed sepearate delete icon and     
-                                                      made it part of card
-            <div />
-          ) : (
-            <Fragment>
-              <Button
-                variant="text"
-                size="small"
-                color="default"
-                aria-label="Delete"
-                className={classes.margin}
-                onClick={() =>
-                  deleteComponent({
-                    componentId: id,
-                    stateComponents: components,
-                  })
-                }
-                style={{
-                  color: '#D3D3D3',
-                  marginBottom: '10px',
-                  marginTop: '4px',
-                  marginLeft: '11px',
-                  padding: '0px',
-                }}
-              >
-                <DeleteIcon style={{ color: '#D3D3D3' }} />
-                <span style={{ marginTop: '3px' }}>Delete Component</span>
-              </Button>
-            </Fragment>
-          )} */}
         </div>
       </Grid>
       {/* {Create the '+' symbol that add's components as children.} */}
@@ -279,7 +248,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
     </Grid>
   );
 };
-function styles(themes: any): any {
+function styles(): object {
   return {
     root: {
       width: '100%',

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -80,7 +80,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
           {/* {This is the component responsible for the collapsing transition animation for each component card} */}
           <Collapse
             in={focusedToggle}
-            collapsedHeight={'70px'} //The type for the Collapse component is asking for a string, but if you put in a string and not a number, the component itself breaks.
+            collapsedHeight={'80px'} //The type for the Collapse component is asking for a string, but if you put in a string and not a number, the component itself breaks.
             style={{ borderRadius: '5px' }}
             timeout={500}
           >

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -63,6 +63,8 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
   // state/class toggles will be displayed when a component is focused
   const focusedToggle = isFocused() === 'focused' ? true : false;
 
+  //this function determines whether edit mode for component name should be entered or not
+  //resets the title if 'escape' key is hit
   const handleEdit = () => {
     if (editMode !== id) {
       handleChangeName(title);
@@ -125,7 +127,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                   // button // commented out to disable materialUI hover shading effect. TBD if any adverse effects occur
                   // style={{ color: 'red' }}
                   onClick={() => {
-                    if (focusComponent.title !== title)
+                    if (focusComponent.title !== title) //changed the logic here so it only focuses if you click on a different card. Otherwise, you can't double click into edit mode for the title. 
                       changeFocusComponent({ title });
                   }}
                 >
@@ -147,32 +149,32 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                             {title}
                           </Typography>
                         ) : (
-                          <TextField
+                          <TextField                                      //show a text field for editing instead if edit mode entered
                             id="filled"
                             label="Change Component Name"
                             defaultValue={title}
                             variant="outlined"
                             className={classes.text}
                             InputProps={{
-                              className: classes.light,
+                              className: classes.light,                   //all of these styling makes the input box border, label, and text default to white.
                             }}
                             InputLabelProps={{
                               className: classes.inputLabel,
                             }}
                             autoFocus
-                            onChange={e => handleChangeName(e.target.value)}
+                            onChange={e => handleChangeName(e.target.value)}      //event handler for key press
                             onKeyPress={ev => {
-                              if (ev.key === 'Enter') {
+                              if (ev.key === 'Enter') {                           //event handler for enter pressed
                                 handleEditComponent();
                                 ev.preventDefault();
                               }
                             }}
-                            onKeyUp={ev => {
-                              if (ev.keyCode === 27) {
-                                handleEdit();
-                                ev.preventDefault();
-                              }
-                            }}
+                            // onKeyUp={ev => {                                   //the old escape handler, keeping it here just in case a bug in the main.js escape handler wasn't caught
+                            //   if (ev.keyCode === 27) {
+                            //     handleEdit();
+                            //     ev.preventDefault();
+                            //   }
+                            // }}
                           />
                         )}
                         {/* ALL OF THE STATE/CLASS TOGGLES AND LABELS ARE ONLY RENDERED IF THEIR COMPONENT IS THE FOCUSED COMPONENT 

--- a/src/components/LeftColExpansionPanel.tsx
+++ b/src/components/LeftColExpansionPanel.tsx
@@ -313,12 +313,15 @@ function styles(): object {
     light: {
       color: '#eee',
       '&:hover': {
-        color: '#1de9b6',
+        color: '#fff',
       },
     },
     inputLabel: {
       fontSize: '16px',
       color: '#fff',
+      '&.Mui-focused': {
+        color: '#fff',
+      },
     },
     text: {
       '& .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline': {

--- a/src/components/Props.tsx
+++ b/src/components/Props.tsx
@@ -2,18 +2,14 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { withStyles, Theme } from '@material-ui/core/styles';
 import FormControl from '@material-ui/core/FormControl';
-import Grow from '@material-ui/core/Grow';
-import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
-import Input from '@material-ui/core/Input';
 import Select from '@material-ui/core/Select';
-import Switch from '@material-ui/core/Switch';
 import InputLabel from '@material-ui/core/InputLabel';
 import { addProp, deleteProp } from '../actions/components';
 import DataTable from './DataTable';
-import { ComponentInt, PropInt, PropsInt } from '../utils/Interfaces';
+import { PropInt, PropsInt } from '../utils/Interfaces';
 
 interface PropsPropsInt extends PropsInt {
   classes: any;
@@ -21,7 +17,7 @@ interface PropsPropsInt extends PropsInt {
   deleteProp(propId: number): void;
 }
 
-const styles = (theme: any) => ({
+const styles = () => ({
   root: {
     display: 'flex',
     justifyContent: 'center',

--- a/src/containers/AppContainer.tsx
+++ b/src/containers/AppContainer.tsx
@@ -32,6 +32,7 @@ interface Props {
   undo(): void;
   redo(): void;
   tutorial: number;
+  toggleEditMode(arg: {id: number}): void;
 }
 
 //Type for the state that should not be assigned within the
@@ -67,6 +68,8 @@ const mapDispatchToProps = (dispatch: (arg: any) => void) => ({
     dispatch(actions.changeTutorial(tutorial)),
   undo: () => dispatch(actions.undo()),
   redo: () => dispatch(actions.redo()),
+  toggleEditMode: ({ id }: { id: number }) =>
+    dispatch(actions.toggleEditMode({ id })),
 });
 
 class AppContainer extends Component<Props, State> {
@@ -111,6 +114,10 @@ class AppContainer extends Component<Props, State> {
     IPC.on('redo', () => {
       this.props.redo();
     });
+
+    IPC.on('escape', () => {
+      this.props.toggleEditMode({id:-1});
+    })
   }
 
   handleNext = (tutorial: number) => {

--- a/src/containers/LeftContainer.tsx
+++ b/src/containers/LeftContainer.tsx
@@ -76,10 +76,10 @@ const mapDispatchToProps = (dispatch: any) => ({
     componentId: number;
     stateComponents: ComponentsInt;
   }) => dispatch(actions.deleteComponent({ componentId, stateComponents })),
-  toggleComponentState: (id: string) =>
-    dispatch(actions.toggleComponentState(id)),
-  toggleComponentClass: (id: string) =>
-    dispatch(actions.toggleComponentClass(id)),
+  toggleComponentState: ({ id }: { id: number }) =>
+    dispatch(actions.toggleComponentState({ id })),
+  toggleComponentClass: ({ id }: { id: number }) =>
+    dispatch(actions.toggleComponentClass({ id })),
   deleteAllData: () => dispatch(actions.deleteAllData()),
   deleteImage: () => dispatch(actions.deleteImage()),
   createApp: ({
@@ -98,7 +98,7 @@ const mapDispatchToProps = (dispatch: any) => ({
         genOption,
         appName: 'reactype_app',
         exportAppBool: null,
-      }),
+      })
     ),
 });
 
@@ -119,7 +119,7 @@ class LeftContainer extends Component<LeftContPropsInt, StateInt> {
       imageSource: this.props.imageSource,
     };
 
-    IPC.on('app_dir_selected', (event: any, path: string) => {
+    IPC.on('app_dir_selected', (event: string, path: string) => {
       const { components } = this.props;
       const { genOption } = this.state;
       this.props.createApp({
@@ -435,5 +435,5 @@ function styles(): any {
 
 export default compose(
   withStyles(styles),
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps)
 )(LeftContainer);

--- a/src/containers/LeftContainer.tsx
+++ b/src/containers/LeftContainer.tsx
@@ -140,6 +140,7 @@ class LeftContainer extends Component<LeftContPropsInt, StateInt> {
     });
   }
 
+  //this function is for handling the value of the new component name typed in
   handleChange = (event: any) => {
     const newValue: string = event.target.value;
     this.setState({
@@ -147,6 +148,7 @@ class LeftContainer extends Component<LeftContPropsInt, StateInt> {
     });
   };
 
+  //this functions handles the values for an edited name being typed
   handleChangeName = (value: string) => {
     const newValue: string = value;
     this.setState({
@@ -154,6 +156,7 @@ class LeftContainer extends Component<LeftContPropsInt, StateInt> {
     });
   };
 
+  
   handleAddComponent = () => {
     this.props.addComponent({ title: this.state.componentName });
 
@@ -169,7 +172,7 @@ class LeftContainer extends Component<LeftContPropsInt, StateInt> {
       title: this.state.componentEditName,
     });
 
-    // reset the currently added componentName state field to blank after adding
+    // reset the currently added componentName state field to blank after editing
     this.setState({
       componentEditName: '',
     });

--- a/src/reducers/componentReducer.ts
+++ b/src/reducers/componentReducer.ts
@@ -19,7 +19,7 @@ import {
   CHANGE_IMAGE_SOURCE,
   DELETE_IMAGE,
   EXPORT_FILES,
-  CREATE_APPLICATION, //unsued
+  CREATE_APPLICATION, //unused
   EXPORT_FILES_SUCCESS,
   EXPORT_FILES_ERROR,
   CREATE_APPLICATION_ERROR, //unused
@@ -35,6 +35,8 @@ import {
   UPDATE_CHILDREN_SORT,
   UNDO,
   REDO,
+  EDIT_MODE,
+  EDIT_COMPONENT
 } from '../actionTypes/index';
 
 import {
@@ -59,6 +61,8 @@ import {
   updateChildrenSort,
   toggleComponentState,
   toggleComponentClass,
+  toggleEditMode,
+  editComponent,
   undo,
   redo
 } from '../utils/componentReducer.util';
@@ -112,6 +116,7 @@ const initialApplicationState: ApplicationStateInt = {
   ancestors: [],
   initialApplicationFocusChild,
   focusChild: cloneDeep(initialApplicationFocusChild),
+  editMode: -1,
   components: [appComponent],
   appDir: '',
   loading: false,
@@ -139,6 +144,8 @@ const componentReducer = (state = initialApplicationState, action: Action) => {
       return deleteChild(state, action.payload);
     case DELETE_COMPONENT:
       return deleteComponent(state, action.payload);
+      case EDIT_COMPONENT:
+        return editComponent(state, action.payload);
     case TOGGLE_STATE:
       return toggleComponentState(state, action.payload);
     case TOGGLE_CLASS:
@@ -174,6 +181,8 @@ const componentReducer = (state = initialApplicationState, action: Action) => {
       return addProp(state, action.payload);
     case DELETE_PROP:
       return deleteProp(state, action.payload);
+      case EDIT_MODE:
+        return toggleEditMode(state, action.payload);
     case UPDATE_HTML_ATTR:
       return updateHtmlAttr(state, action.payload);
     case UPDATE_CHILDREN_SORT:

--- a/src/utils/Interfaces.ts
+++ b/src/utils/Interfaces.ts
@@ -75,6 +75,7 @@ export interface ApplicationStateInt {
   focusChild: ChildInt;
   components: ComponentsInt;
   appDir: string;
+  editMode: number;
   loading: boolean;
   history: ApplicationStateInt[];
   historyIndex: number;

--- a/src/utils/componentReducer.util.ts
+++ b/src/utils/componentReducer.util.ts
@@ -501,7 +501,7 @@ export const deleteComponent = (
 //Reducer that toggles the component statefulness
 export const toggleComponentState = (
   state: ApplicationStateInt,
-  id: number
+  { id }: { id: number }
 ) => {
   //creates a deep copy of the components array
   const componentCopy = cloneDeep(state.components);
@@ -512,6 +512,7 @@ export const toggleComponentState = (
       element.stateful = !element.stateful;
     }
   });
+  
   // return state and updated components array
   const { history, historyIndex, future } = createHistory(state);
 
@@ -527,7 +528,7 @@ export const toggleComponentState = (
 //Reducer that toggles the component class
 export const toggleComponentClass = (
   state: ApplicationStateInt,
-  id: number
+  { id }: { id: number }
 ) => {
   //creates a deep copy of the components array
   const componentCopy = cloneDeep(state.components);

--- a/src/utils/componentReducer.util.ts
+++ b/src/utils/componentReducer.util.ts
@@ -551,6 +551,7 @@ export const toggleComponentClass = (
   };
 };
 
+//a reducer function to see if component name editing mode should be entered
 export const toggleEditMode = (
   state: ApplicationStateInt,
   { id }: { id: number }
@@ -566,6 +567,10 @@ export const toggleEditMode = (
   };
 };
 
+/*For the function below, it first changes the title of the component being edited to the new name.
+Then, it checks for each child component that exists and make sure the names of those child components 
+are changed as well. Otherwise, the code will break because when you focus on a component with the changed component
+as a child. */
 export const editComponent = (
   state: ApplicationStateInt,
   { id, title }: { id: number; title: string }

--- a/src/utils/componentReducer.util.ts
+++ b/src/utils/componentReducer.util.ts
@@ -10,6 +10,7 @@ import {
   ComponentsInt,
   PropInt
 } from './Interfaces';
+import { createHistory } from './helperFunctions'
 
 //this is the default values for any component added to the app.
 
@@ -30,25 +31,6 @@ const initialComponentState: ComponentInt = {
   childrenArray: [],
   nextChildId: 1,
   focusChildId: 0
-};
-
-/*Helper function that copies the state to be added on to the history
-  By clearing the history data out of each stored step of the timeline,
-  you can avoid repetitive nesting that maxes out the memory allocated to electron
-  (usually happens at around 7-10 steps without using this method)*/
-const createHistory = (state: ApplicationStateInt) => {
-  const stateCopy = cloneDeep(state);
-  const historyCopy = cloneDeep(state.history);
-  historyCopy.push({ ...stateCopy, history: [] });
-  const history = historyCopy;
-  const historyIndex = state.historyIndex + 1;
-  const future: [] = [];
-
-  return {
-    history,
-    historyIndex,
-    future
-  };
 };
 
 export const addComponent = (

--- a/src/utils/componentReducer.util.ts
+++ b/src/utils/componentReducer.util.ts
@@ -8,9 +8,9 @@ import {
   //ChildrenInt, //unused import//
   ChildInt,
   ComponentsInt,
-  PropInt
+  PropInt,
 } from './Interfaces';
-import { createHistory } from './helperFunctions'
+import { createHistory } from './helperFunctions';
 
 //this is the default values for any component added to the app.
 
@@ -26,11 +26,11 @@ const initialComponentState: ComponentInt = {
     x: 25,
     y: 25,
     width: 800,
-    height: 550
+    height: 550,
   },
   childrenArray: [],
   nextChildId: 1,
-  focusChildId: 0
+  focusChildId: 0,
 };
 
 export const addComponent = (
@@ -50,14 +50,14 @@ export const addComponent = (
       `A component with the name: "${strippedTitle}" already exists.\n Please think of another name.`
     );
     return {
-      ...state
+      ...state,
     };
   }
 
   // empty component name not allowed
   if (strippedTitle === '') {
     return {
-      ...state
+      ...state,
     };
   }
 
@@ -80,7 +80,7 @@ export const addComponent = (
     title: strippedTitle,
     id: componentId,
     color: componentColor,
-    childrenArray: []
+    childrenArray: [],
   };
 
   const components = [...state.components, newComponent];
@@ -114,7 +114,7 @@ export const addComponent = (
     selectableChildren, // new component so everyone except yourself is available
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -124,7 +124,7 @@ export const addChild = (
   {
     title,
     childType = '',
-    HTMLInfo = {}
+    HTMLInfo = {},
   }: {
     title: string;
     childType: string;
@@ -186,13 +186,13 @@ export const addChild = (
           x: view.position.x + ((view.nextChildId * 16) % 150), // new children are offset by some amount, map of 150px
           y: view.position.y + ((view.nextChildId * 16) % 150),
           width: parentComponent.position.width - 1, // new children have an initial position of their CLASS (maybe don't need 90%)
-          height: parentComponent.position.height - 1
+          height: parentComponent.position.height - 1,
         }
       : {
           x: view.position.x + view.nextChildId * 16,
           y: view.position.y + view.nextChildId * 16,
           width: htmlElemPosition.width,
-          height: htmlElemPosition.height
+          height: htmlElemPosition.height,
         };
 
   const newChild: ChildInt = {
@@ -204,7 +204,7 @@ export const addChild = (
     position: newPosition,
     color: null, // parentComponent.color, // only relevant fot children of type COMPONENT
     htmlElement, // only relevant fot children of type HTML
-    HTMLInfo
+    HTMLInfo,
   };
 
   const compsChildrenArr = [...view.childrenArray, newChild];
@@ -214,14 +214,14 @@ export const addChild = (
     ...view,
     childrenArray: compsChildrenArr,
     focusChildId: newChild.childId,
-    nextChildId: view.nextChildId + 1
+    nextChildId: view.nextChildId + 1,
   };
 
   const components = [
     ...state.components.filter((comp: ComponentInt) => {
       if (comp.title !== view.title) return comp;
     }),
-    component
+    component,
   ];
   const { history, historyIndex, future } = createHistory(state);
 
@@ -232,7 +232,7 @@ export const addChild = (
     focusComponent: component, // refresh the focus component so we have the new child
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -241,7 +241,7 @@ export const deleteChild = (
   {
     parentId = state.focusComponent.id,
     childId = state.focusChild.childId,
-    calledFromDeleteComponent = false
+    calledFromDeleteComponent = false,
   }
 ) => {
   /** ************************************************
@@ -283,7 +283,7 @@ export const deleteChild = (
 
   const modifiedComponentArray = [
     ...state.components.filter((comp: ComponentInt) => comp.id !== parentId), // all elements besides the one just changed
-    parentComponentCopy
+    parentComponentCopy,
   ];
 
   const { history, historyIndex, future } = createHistory(state);
@@ -301,7 +301,7 @@ export const deleteChild = (
         ] || cloneDeep(state.initialApplicationFocusChild), // guard in case final child is deleted
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -316,7 +316,7 @@ export const deleteImage = (state: ApplicationStateInt) => {
     imageSource: '',
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -329,7 +329,7 @@ export const handleTransform = (
     x,
     y,
     width,
-    height
+    height,
   }: {
     componentId: number;
     childId: number;
@@ -352,8 +352,8 @@ export const handleTransform = (
         x: x || component.position.x,
         y: y || component.position.y,
         width: width || component.position.width,
-        height: height || component.position.height
-      }
+        height: height || component.position.height,
+      },
     };
 
     //return state with updated component values
@@ -361,7 +361,7 @@ export const handleTransform = (
       ...state.components.filter((comp: ComponentInt) => {
         if (comp.id !== componentId) return comp;
       }),
-      transformedComponent
+      transformedComponent,
     ];
     return { ...state, components };
   }
@@ -377,8 +377,8 @@ export const handleTransform = (
       x: x || child.position.x,
       y: y || child.position.y,
       width: width || child.position.width,
-      height: height || child.position.height
-    }
+      height: height || child.position.height,
+    },
   };
 
   const children = [
@@ -387,7 +387,7 @@ export const handleTransform = (
       .childrenArray.filter((child: ChildInt) => {
         if (child.childId !== childId) return child;
       }),
-    transformedChild
+    transformedChild,
   ];
 
   let newFocusChild = state.focusChild;
@@ -398,14 +398,14 @@ export const handleTransform = (
   const component = {
     ...state.components.find((comp: ComponentInt) => comp.id === componentId),
     childrenArray: children,
-    focusChild: newFocusChild
+    focusChild: newFocusChild,
   };
 
   const components: ComponentsInt = [
     ...state.components.filter((comp: ComponentInt) => {
       if (comp.id !== componentId) return comp;
     }),
-    component
+    component,
   ];
   const { history, historyIndex, future } = createHistory(state);
 
@@ -415,7 +415,7 @@ export const handleTransform = (
     focusChild: newFocusChild,
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -426,7 +426,7 @@ export const changeTutorial = (
 ) => {
   return {
     ...state,
-    tutorial
+    tutorial,
   };
 };
 
@@ -442,7 +442,7 @@ export const changeImageSource = (
     imageSource,
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -463,14 +463,14 @@ export const deleteComponent = (
   if (!result) {
     return {
       ...state,
-      focusComponent: compName[0]
+      focusComponent: compName[0],
     };
   }
   //if app is selected, return state
   //is this really necessary if the App component is disabled from being deleted? -Tony
   if (componentId === 1) {
     return {
-      ...state
+      ...state,
     };
   }
 
@@ -494,7 +494,7 @@ export const deleteComponent = (
     components: componentsCopy,
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -512,7 +512,7 @@ export const toggleComponentState = (
       element.stateful = !element.stateful;
     }
   });
-  
+
   // return state and updated components array
   const { history, historyIndex, future } = createHistory(state);
 
@@ -521,7 +521,7 @@ export const toggleComponentState = (
     components: componentCopy,
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -547,7 +547,45 @@ export const toggleComponentClass = (
     components: componentCopy,
     history,
     historyIndex,
-    future
+    future,
+  };
+};
+
+export const toggleEditMode = (
+  state: ApplicationStateInt,
+  { id }: { id: number }
+) => {
+  if (id === 1) {
+    return {
+      ...state,
+    };
+  }
+  return {
+    ...state,
+    editMode: id,
+  };
+};
+
+export const editComponent = (
+  state: ApplicationStateInt,
+  { id, title }: { id: number; title: string }
+) => {
+  let components = cloneDeep(state.components);
+  let toEdit = components.find((element: ComponentInt) => element.id === id);
+  toEdit.title = title;
+  for (const [index, each] of components.entries()) {
+    for (const value of each.childrenArray) {
+      if (value.childComponentId === id) {
+        value.componentName = title;
+      }
+    }
+  }
+
+  return {
+    ...state,
+    focusChild: state.initialApplicationFocusChild,
+    editMode: -1,
+    components,
   };
 };
 
@@ -580,10 +618,11 @@ export const changeFocusComponent = (
 
   return {
     ...state,
+    editMode: -1,
     focusComponent: newFocusComp,
     selectableChildren: result.selectableChildren,
     ancestors: result.ancestors,
-    focusChild: newFocusChild
+    focusChild: newFocusChild,
   };
 };
 
@@ -607,19 +646,19 @@ export const changeFocusChild = (
         x: focComp.position.x,
         y: focComp.position.y,
         width: focComp.position.width,
-        height: focComp.position.height
+        height: focComp.position.height,
       },
       childSort: 0,
       color: focComp.color,
       childType: '',
       htmlElement: '',
-      HTMLInfo: {}
+      HTMLInfo: {},
     };
   }
 
   return {
     ...state,
-    focusChild: newFocusChild
+    focusChild: newFocusChild,
   };
 };
 
@@ -637,7 +676,7 @@ export const changeComponentFocusChild = (
   );
   return {
     ...state,
-    components: [modifiedComponent, ...components]
+    components: [modifiedComponent, ...components],
   };
 };
 
@@ -648,7 +687,7 @@ export const exportFilesSuccess = (
   ...state,
   successOpen: status,
   appDir: dir,
-  loading: false
+  loading: false,
 });
 
 export const exportFilesError = (
@@ -658,20 +697,20 @@ export const exportFilesError = (
   ...state,
   errorOpen: status,
   appDir: err,
-  loading: false
+  loading: false,
 });
 
 export const handleClose = (state: ApplicationStateInt, status: string) => ({
   ...state,
   errorOpen: status,
-  successOpen: status
+  successOpen: status,
 });
 
 export const openExpansionPanel = (
   state: ApplicationStateInt,
   { component }: { component: ComponentInt }
 ) => ({
-  ...state
+  ...state,
 });
 
 export const addProp = (
@@ -680,7 +719,7 @@ export const addProp = (
     key,
     value = null,
     required,
-    type
+    type,
   }: { key: string; value: string; required: boolean; type: string }
 ) => {
   if (!state.focusComponent.id) {
@@ -697,14 +736,14 @@ export const addProp = (
     key,
     value: value || key,
     required,
-    type
+    type,
   };
   const newProps = [...selectedComponent.props, newProp];
 
   const modifiedComponent: ComponentInt = {
     ...selectedComponent,
     props: newProps,
-    nextPropId: selectedComponent.nextPropId + 1
+    nextPropId: selectedComponent.nextPropId + 1,
   };
 
   const newComponents: ComponentsInt = state.components.filter(
@@ -719,7 +758,7 @@ export const addProp = (
     focusComponent: modifiedComponent,
     historyIndex,
     history,
-    future
+    future,
   };
 };
 
@@ -759,7 +798,7 @@ export const deleteProp = (state: ApplicationStateInt, propId: number) => {
     focusComponent: modifiedComponent,
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -801,7 +840,7 @@ export const updateHtmlAttr = (
     focusChild: modifiedChild,
     history,
     historyIndex,
-    future
+    future,
   };
 };
 
@@ -839,7 +878,7 @@ export const updateChildrenSort = (
   return {
     ...state,
     components: modifiedComponentsArray,
-    focusComponent: modifiedComponent
+    focusComponent: modifiedComponent,
   };
 };
 
@@ -859,7 +898,7 @@ export const undo = (state: ApplicationStateInt) => {
   return {
     ...undoData,
     history,
-    future
+    future,
   };
 };
 
@@ -879,6 +918,6 @@ export const redo = (state: ApplicationStateInt) => {
   return {
     ...redoData,
     history,
-    future
+    future,
   };
 };

--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -1,0 +1,21 @@
+import { ApplicationStateInt } from './Interfaces';
+import cloneDeep from './cloneDeep';
+
+/*Helper function that copies the state to be added on to the history
+  By clearing the history data out of each stored step of the timeline,
+  you can avoid repetitive nesting that maxes out the memory allocated to electron
+  (usually happens at around 7-10 steps without using this method)*/
+export const createHistory = (state: ApplicationStateInt) => {
+  const stateCopy = cloneDeep(state);
+  const historyCopy = cloneDeep(state.history);
+  historyCopy.push({ ...stateCopy, history: [] });
+  const history = historyCopy;
+  const historyIndex = state.historyIndex + 1;
+  const future: [] = [];
+
+  return {
+    history,
+    historyIndex,
+    future,
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "commonjs",
     "target": "es6",
     "jsx": "react",
-    "lib": ["es6", "dom", "es2017"],
+    "lib": ["es5","es6", "dom", "es2017"],
     "allowSyntheticDefaultImports": true
   },
   "include": ["./src/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "commonjs",
     "target": "es6",
     "jsx": "react",
-    "lib": ["es5","es6", "dom", "es2017"],
+    "lib": ["es6", "dom", "es2017"],
     "allowSyntheticDefaultImports": true
   },
   "include": ["./src/**/*"]


### PR DESCRIPTION
**Problem**

Although many components could be added or removed, there was no functionality to edit the component names once they were created. 

**Solution**

A simple way to edit component names was created.

- Double-click on the component name to enter edit mode

- Press enter to change the name

- Press escape from anywhere in the app or change the component focus to leave edit mode

![Peek 2020-03-21 20-57](https://user-images.githubusercontent.com/14224294/77242140-805db200-6bb8-11ea-87d3-8e45bd89a5b2.gif)


**Updates**

- Escape key listener created globally

- Material-UI 'styles' moved from dev dependency to build dependency

- Two new action types created: EDIT_MODE and EDIT_COMPONENT, with corresponding dispatch functions, action creators, and reducer functions

- ToggleComponentState and Class arguments for 'id' converted to object { id } got consistency (this will later be done for other actions and reducers as well.)

- Deleted a large comment block from the old 'delete component' button

- Card height when collapsed fixed to 80px. 

- Typescript fixes where needed

- Added a new property in the global store 'editMode' with the **number** type

- 'createHistory' function moved to a separate helper function file, to not clutter the reducer file

- Trailing commas added where needed automatically through prettier, in line with Airbnb styling rules

- changeFocusComponent function will no longer be triggered when clicking on already focused component, allowing for double-clicking and avoiding unnecessary memory use
