### PR TITLE
Added Typing to onChange events and fixed styling in bottom panel

### DIFF
--- a/src/components/bottom/CodePreview.tsx
+++ b/src/components/bottom/CodePreview.tsx
@@ -19,7 +19,6 @@ type CodePreviewProps = {
 };
 
 class CodePreview extends Component<CodePreviewProps> {
-
   //checking if the code has been asigned yet or not
   //if no then generate code and asign to a focus component
   componentDidMount() {
@@ -67,10 +66,10 @@ class CodePreview extends Component<CodePreviewProps> {
         }}
       >
         <AceEditor
-          mode="javascript"
-          theme="monokai"
-          width="100%"
-          height="100%"
+          mode='javascript'
+          theme='monokai'
+          width='100%'
+          height='100%'
           style={{
             border: '2px solid #33eb91',
             borderRadius: '8px'
@@ -82,19 +81,19 @@ class CodePreview extends Component<CodePreviewProps> {
             })
           }
           value={this.props.focusComponent.code}
-          name="Code_div"
+          name='Code_div'
           readOnly={this.props.codeReadOnly}
           editorProps={{ $blockScrolling: true }}
           fontSize={16}
         />
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           <Button
-            color="primary"
-            aria-label="Add"
-            type="submit"
+            color='primary'
+            aria-label='Add'
+            type='submit'
             // disabled={!this.state.propKey || !this.state.propType}
-            variant="contained"
-            size="large"
+            variant='contained'
+            size='large'
             style={{ justifySelf: 'center' }}
             className={this.props.classes.startEdit}
             onClick={e => {

--- a/src/components/bottom/DataTable.tsx
+++ b/src/components/bottom/DataTable.tsx
@@ -12,7 +12,7 @@ import { IconButton } from '@material-ui/core';
 const styles = (theme: Theme) => ({
   root: {
     width: '80%',
-    marginTop: theme.spacing.unit * 3,
+    marginTop: theme.spacing(3),
     marginRight: '100px'
     // overflowX: "auto"
   },

--- a/src/components/bottom/HtmlAttr.tsx
+++ b/src/components/bottom/HtmlAttr.tsx
@@ -14,10 +14,10 @@ import { HTMLelements } from '../../utils/htmlElements.util';
 import { PropsInt, PropInt } from '../../interfaces/Interfaces';
 
 interface HTMLAttrPropsInt extends PropsInt {
-  classes: any;
-  updateHtmlAttr(arg: { attr: string; value: string }): void;
-  deleteProp(id: number): void;
-  addProp(prop: PropInt): void;
+  /*JZ: had to make all props optional, for PropsInt as well, due to typing errors in parent component
+  because no props were passed down since they are all obtained from redux store */
+  classes?: any;
+  updateHtmlAttr?: (arg: { attr: string; value: string }) => void;
 }
 
 interface StateInt {}
@@ -188,7 +188,10 @@ class HtmlAttr extends Component<HTMLAttrPropsInt, StateInt> {
                   className={classes.select}
                   id='htmlType'
                   placeholder='title'
-                  onChange={event => this.handleChange(event)}
+                  // TS expects a change event type, so it must be specified in the onChange events
+                  onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                    this.handleChange(event)
+                  }
                   value={buttonTypeTemp}
                   defaultValue={`${``}`}
                   required
@@ -211,7 +214,9 @@ class HtmlAttr extends Component<HTMLAttrPropsInt, StateInt> {
                 label={attr}
                 variant='outlined'
                 id={attr}
-                onChange={this.handleChange}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  this.handleChange(event)
+                }
                 value={this.state[attr]}
               />
             )}

--- a/src/components/bottom/Props.tsx
+++ b/src/components/bottom/Props.tsx
@@ -17,6 +17,13 @@ interface PropsPropsInt extends PropsInt {
   deleteProp(propId: number): void;
 }
 
+interface StateInt {
+  propVariable: string;
+  propValue: string;
+  propRequired: boolean;
+  propType: string;
+}
+
 const styles = () => ({
   root: {
     display: 'flex',
@@ -151,9 +158,6 @@ const availablePropTypes = {
   array: 'ARR',
   boolean: 'BOOL',
   function: 'FUNC',
-  // symbol: 'SYM',
-  // node: 'NODE',
-  // element: 'ELEM',
   any: 'ANY',
   tuple: 'TUP',
   enum: 'ENUM'
@@ -161,19 +165,14 @@ const availablePropTypes = {
 
 // generates the various options for the prop type selection
 const typeOptions = [
-  <option value="" key="" />,
+  <option value='' key='' />,
   ...Object.keys(availablePropTypes).map(type => (
     <option value={type} key={type} style={{ color: '#000' }}>
       {type}
     </option>
   ))
 ];
-interface StateInt {
-  propVariable: string;
-  propValue: string;
-  propRequired: boolean;
-  propType: string;
-}
+
 class Props extends Component<PropsPropsInt, StateInt> {
   constructor(props: PropsPropsInt) {
     super(props);
@@ -186,14 +185,19 @@ class Props extends Component<PropsPropsInt, StateInt> {
   }
 
   // using useState to locally check a clickedValue
-
-  handleChange = (event: MouseEvent | any) => {
+  // React.ChangeEvent<HTML...Element> is the correct typing for events
+  handleChange = (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLSelectElement>
+  ) => {
     if (event.target.id === 'propVariable') {
       this.setState({
         [event.target.id]: event.target.value.trim()
       });
     } else {
       this.setState({
+        ...this.state, // JZ: added state here to correct typing error of missing properties
         [event.target.id]: event.target.value
       });
     }
@@ -208,7 +212,7 @@ class Props extends Component<PropsPropsInt, StateInt> {
   // function that handles the addition of props to a given componnent
   // added regex to strip usr input from non alpha numeric properties
   // presence of these characters crashes the app and should not be a valid input anyways
-  handleAddProp = (event: MouseEvent) => {
+  handleAddProp = (event: React.ChangeEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     // destructuring from local state
@@ -292,24 +296,33 @@ class Props extends Component<PropsPropsInt, StateInt> {
               </span>
             </div>
             <div
-              className="props-container"
+              className='props-container'
               style={{ marginTop: '20px', width: '90%', height: '80%' }}
             >
               <Grid container spacing={8}>
                 <Grid item xs={3}>
-                  <form className="props-input" onSubmit={this.handleAddProp}>
+                  <form
+                    className='props-input'
+                    // JZ: assigned typing to onSubmit event, matches handleAddProp func
+                    onSubmit={(event: React.ChangeEvent<HTMLFormElement>) =>
+                      this.handleAddProp(event)
+                    }
+                  >
                     <Grid container spacing={8}>
                       <Grid item xs={6}>
                         <FormControl>
                           <TextField
-                            type="text"
-                            native
-                            id="propVariable"
-                            label="Prop"
-                            margin="none"
+                            type='text'
+                            // native commented out due to overload error with material
+                            id='propVariable'
+                            label='Prop'
+                            margin='none'
                             autoFocus
-                            size="medium"
-                            onChange={this.handleChange}
+                            size='medium'
+                            onChange={(
+                              //JZ: assigned typing to incoming event
+                              event: React.ChangeEvent<HTMLInputElement>
+                            ) => this.handleChange(event)}
                             value={this.state.propVariable}
                             color={'primary'}
                             required
@@ -342,15 +355,15 @@ class Props extends Component<PropsPropsInt, StateInt> {
                         <FormControl required>
                           <InputLabel
                             className={classes.selectLabel}
-                            htmlFor="propType"
+                            htmlFor='propType'
                           >
                             Type
                           </InputLabel>
                           <Select
                             native
                             className={classes.select}
-                            id="propType"
-                            placeholder="title"
+                            id='propType'
+                            placeholder='title'
                             onChange={this.handleChange}
                             value={this.state.propType}
                             required
@@ -378,12 +391,12 @@ class Props extends Component<PropsPropsInt, StateInt> {
                       </Grid> */}
                       <Grid item>
                         <Button
-                          color="primary"
-                          aria-label="Add"
-                          type="submit"
+                          color='primary'
+                          aria-label='Add'
+                          type='submit'
                           // disabled={!this.state.propKey || !this.state.propType}
-                          variant="contained"
-                          size="large"
+                          variant='contained'
+                          size='large'
                           className={classes.addProp}
                         >
                           ADD PROP

--- a/src/components/bottom/Props.tsx
+++ b/src/components/bottom/Props.tsx
@@ -266,7 +266,10 @@ class Props extends Component<PropsPropsInt, StateInt> {
     }));
 
     return (
-      <div className={'htmlattr'}>
+      <div
+        className={'htmlattr'}
+        style={{ overflowY: 'auto', height: '85%', marginTop: '1rem' }}
+      >
         {' '}
         {/* if no focus component in state, then render message */}
         {Object.keys(focusComponent).length < 1 ? (
@@ -299,7 +302,7 @@ class Props extends Component<PropsPropsInt, StateInt> {
               className='props-container'
               style={{ marginTop: '20px', width: '90%', height: '80%' }}
             >
-              <Grid container spacing={8}>
+              <Grid container spacing={8} style={{ overflowY: 'auto' }}>
                 <Grid item xs={3}>
                   <form
                     className='props-input'
@@ -409,10 +412,12 @@ class Props extends Component<PropsPropsInt, StateInt> {
                   item
                   xs={8}
                   style={{
-                    height: '17rem',
-                    overflow: 'scroll',
+                    height: '75%',
+                    overflowY: 'auto',
+                    overflowX: 'auto',
                     marginTop: '1rem',
-                    paddingBottom: '1rem',
+                    // paddingBottom: '1rem',
+                    marginLeft: '6rem',
                     paddingTop: '0'
                   }}
                 >

--- a/src/components/left/HTMLComponentPanel.tsx
+++ b/src/components/left/HTMLComponentPanel.tsx
@@ -38,14 +38,19 @@ class HTMLComponentPanel extends Component<HTMLCompPropsInt, StateInt> {
   render(): JSX.Element {
     const { classes } = this.props;
     return (
-      <div align='center'>
+      <div style={{ textAlign: 'center' }}>
         <Tab
           disableRipple
           classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
-          label='Add HTML elements'
-          style={{ cursor: 'default' }}
+          label='Add HTML Elements'
+          style={{
+            cursor: 'default',
+            fontSize: '1.2em',
+            textShadow: '2px 2px 2px black',
+            paddingBottom: '20px'
+          }}
         />
-        <Grid container spacing={8} alignItems='baseline' align='stretch'>
+        <Grid container spacing={6} alignItems='center'>
           <Grid item xs={4}>
             <div className='htmliconwrapper'>
               <IconButton

--- a/src/components/left/LeftColExpansionPanel.tsx
+++ b/src/components/left/LeftColExpansionPanel.tsx
@@ -14,7 +14,12 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Collapse from '@material-ui/core/Collapse';
 import Switch from '@material-ui/core/Switch'; // for state/class toggling
 import InputLabel from '@material-ui/core/InputLabel'; // labeling of state/class toggles
-import { ComponentInt, ComponentsInt, PropsInt } from '../../interfaces/Interfaces'; // unused
+import {
+  ComponentInt,
+  ComponentsInt,
+  PropsInt
+} from '../../interfaces/Interfaces'; // unused
+
 interface LeftColExpPanPropsInt extends PropsInt {
   classes: any;
   id?: number;
@@ -57,15 +62,16 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
     handleChangeName,
     handleEditComponent
   } = props;
+
   const { title, id, color, stateful, classBased } = component;
+
   function isFocused() {
     return focusComponent.id === id ? 'focused' : '';
   }
+
   // boolean flag to determine if the component card is focused or not
   // state/class toggles will be displayed when a component is focused
   const focusedToggle = isFocused() === 'focused' ? true : false;
-
-
 
   //this function determines whether edit mode for component name should be entered or not
   //resets the title if 'escape' key is hit
@@ -81,9 +87,9 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
   return (
     <Grid
       container
-      direction="row"
-      justify="center"
-      alignItems="center"
+      direction='row'
+      justify='center'
+      alignItems='center'
       style={{
         minWidth: '470px'
       }}
@@ -106,7 +112,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
             in={focusedToggle}
             collapsedHeight={'80px'} //The type for the Collapse component is asking for a string, but if you put in a string and not a number, the component itself breaks.
             style={{ borderRadius: '5px' }}
-            timeout="auto"
+            timeout='auto'
           >
             {/* NOT SURE WHY COLOR: RED IS USED, TRIED REMOVING IT AND NO VISIBLE CHANGE OCCURED. */}
             <Grid
@@ -156,10 +162,10 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                           </Typography>
                         ) : (
                           <TextField //show a text field for editing instead if edit mode entered
-                            id="filled"
-                            label="Change Component Name"
+                            id='filled'
+                            label='Change Component Name'
                             defaultValue={title}
-                            variant="outlined"
+                            variant='outlined'
                             className={classes.text}
                             InputProps={{
                               className: classes.light //all of these styling makes the input box border, label, and text default to white.
@@ -191,7 +197,7 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                         {focusedToggle ? (
                           <span style={{ display: 'inline-flex' }}>
                             <InputLabel
-                              htmlFor="stateful"
+                              htmlFor='stateful'
                               style={{
                                 color: '#fff',
                                 marginBottom: '0px',
@@ -210,12 +216,12 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                                 toggleComponentState({ id });
                                 changeFocusComponent({ title });
                               }}
-                              value="stateful"
-                              color="primary"
+                              value='stateful'
+                              color='primary'
                               // id={props.id.toString()}
                             />
                             <InputLabel
-                              htmlFor="classBased"
+                              htmlFor='classBased'
                               style={{
                                 color: '#fff',
                                 marginBottom: '0px',
@@ -234,8 +240,8 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                                 toggleComponentClass({ id });
                                 changeFocusComponent({ title });
                               }}
-                              value="classBased"
-                              color="primary"
+                              value='classBased'
+                              color='primary'
                             />
                           </span>
                         ) : (
@@ -243,10 +249,10 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
                         )}
                         {focusedToggle && component.id !== 1 ? (
                           <Button
-                            variant="text"
-                            size="small"
-                            color="default"
-                            aria-label="Delete"
+                            variant='text'
+                            size='small'
+                            color='default'
+                            aria-label='Delete'
                             className={classes.margin}
                             onClick={() =>
                               deleteComponent({
@@ -295,12 +301,12 @@ const LeftColExpansionPanel = (props: LeftColExpPanPropsInt) => {
           <div />
         ) : (
           <Tooltip
-            title="add as child"
-            aria-label="add as child"
-            placement="left"
+            title='add as child'
+            aria-label='add as child'
+            placement='left'
           >
             <IconButton
-              aria-label="Add"
+              aria-label='Add'
               onClick={() => {
                 addChild({ title, childType: 'COMP' });
                 changeFocusComponent({ title: focusComponent.title });

--- a/src/interfaces/Interfaces.ts
+++ b/src/interfaces/Interfaces.ts
@@ -10,7 +10,7 @@ export interface PropInt {
 
 export interface PropsInt {
   focusChild?: ChildInt;
-  components: ComponentsInt;
+  components?: ComponentsInt;
   focusComponent?: ComponentInt;
   imageSource?: string;
   changeFocusChild?: (arg: { childId: number }) => void;


### PR DESCRIPTION
**Problem**
Typescript was throwing errors because incoming onChange events were not typed properly (MouseEvent instead of React.ChangeEvent). Additionally, the bottom panel had some tabs with a persistent scrollbar, and unused vertical space.

**Solution**
Added explicit typing to some of the onChange events and updating CSS for bottom tab panels.