### PR TITLE
add scroll functionality to RightContainer by adding css style and ce…

### DIFF
--- a/app/src/components/left/HTMLPanel.tsx
+++ b/app/src/components/left/HTMLPanel.tsx
@@ -145,6 +145,7 @@ const htmlTypesToRender = state.HTMLTypes.filter(type => type.name !== 'separato
           // direction='column'
           // justify='center'
           // alignItems='center'
+          id="HTMLItemsGrid"
         >
           {htmlTypesToRender.map(option => (
             <HTMLItem

--- a/app/src/containers/RightContainer.tsx
+++ b/app/src/containers/RightContainer.tsx
@@ -277,7 +277,7 @@ const RightContainer = (): JSX.Element => {
   };
 
   return (
-    <div className="column right" style={style}>
+    <div className="column right" id="rightContainer" style={style}>
       <ComponentPanel />
       <ProjectManager />
   {/* -----------------------------MOVED PROJECT MANAGER------------------------------------     */}

--- a/app/src/public/styles/style.css
+++ b/app/src/public/styles/style.css
@@ -136,6 +136,10 @@ LEFT COLUMN
   flex-wrap: wrap;
 }
 
+#HTMLItemsGrid {
+  margin-left: 15px;
+}
+
 #HTMLItem {
   /* transition: background 0.5s ease-in-out; */
   transition: 0.3s;
@@ -312,6 +316,10 @@ h1 {
 RIGHT COLUMN
 /////////////////////////////////////////////
 */
+
+#rightContainer {
+  overflow: scroll;
+}
 
 .export {
   border-top: 1px solid #ccc;


### PR DESCRIPTION
Submitted by Luke Madden

## Types of Changes

- [x] Non-breaking change 

## Purpose
HTML Items rendered in the LeftContainer were not centered and the RightContainer was not scrollable, hiding important functionality
## Approach
Added scrollable overflow property to #RightContainer and adjusted margin-left property to #HTMLItemsGrid 

## Screenshot(s)

style.css
![Screen Shot 2021-01-21 at 11 29 04 AM](https://user-images.githubusercontent.com/73565425/105402419-3da3a680-5bdc-11eb-9037-50ac92e537b2.png)

RightContainer.tsx
![Screen Shot 2021-01-21 at 11 29 17 AM](https://user-images.githubusercontent.com/73565425/105402421-3ed4d380-5bdc-11eb-9f4d-51e6bacd779f.png)

style.css
![Screen Shot 2021-01-21 at 11 28 51 AM](https://user-images.githubusercontent.com/73565425/105402426-409e9700-5bdc-11eb-9b1c-3d0b963e4a27.png)

HTMLPanel.tsx
![Screen Shot 2021-01-21 at 11 29 52 AM](https://user-images.githubusercontent.com/73565425/105402424-40060080-5bdc-11eb-9d55-de96aa1e0104.png)




