### PR TITLE
Tree chart now renders and updates components properly

### DIFF
--- a/app/src/tree/TreeChart.tsx
+++ b/app/src/tree/TreeChart.tsx
@@ -49,10 +49,7 @@ function TreeChart({ data }) { // data is components from state - passed in from
 
   // create a deep clone of data to avoid mutating the actual children array in removing separators
   const dataDeepClone = cloneDeep(data);
-
-  // update all versions of components to match current version
-  
-  // remove separators
+  // remove separators and update components to current versions
   dataDeepClone.forEach(component => {
     removeSeparators(component.children);
   });

--- a/app/src/tree/TreeChart.tsx
+++ b/app/src/tree/TreeChart.tsx
@@ -1,7 +1,7 @@
-import React, { useRef, useEffect, useContext } from "react";
-import { select, hierarchy, tree, linkHorizontal } from "d3";
+import React, { useRef, useEffect, useContext } from 'react';
+import { select, hierarchy, tree, linkHorizontal } from 'd3';
 import cloneDeep from 'lodash/cloneDeep';
-import useResizeObserver from "./useResizeObserver";
+import useResizeObserver from './useResizeObserver';
 import StateContext from '../context/context';
 
 function usePrevious(value) {
@@ -12,7 +12,8 @@ function usePrevious(value) {
   return ref.current;
 }
 
-function TreeChart({ data }) {
+function TreeChart({ data }) { // data is components from state - passed in from BottomTabs
+  console.log('data', data);
   const [state, dispatch] = useContext(StateContext);
   const canvasId = state.canvasFocus.componentId;
 
@@ -32,17 +33,33 @@ function TreeChart({ data }) {
     // loop over array
     for (let i = 0; i < arr.length; i++) {
       // if element is separator, remove it
-      if (arr[i].name === 'separator') arr.splice(i, 1);
+      if (arr[i].name === 'separator') {
+        arr.splice(i, 1);
+        i -= 1;
+      }
       // if element has a children array and that array has length, recursive call
-      if (arr[i].name === 'div' && arr[i].children.length) removeSeparators(arr[i].children);
+      else if ((arr[i].name === 'div' || arr[i].type === 'Component') && arr[i].children.length) {
+        // if element is a component, replace it with the latest version (to update with new HTML elements)
+        if (arr[i].type === 'Component') arr[i] = data.find(component => component.name === arr[i].name);
+        removeSeparators(arr[i].children);
+      }
     }
     // return mutated array
     return arr;
   };
 
+  // const updateComps = (arr) => {
+  //   for (let i = 0;)
+  // }
+
   // create a deep clone of data to avoid mutating the actual children array in removing separators
   const dataDeepClone = cloneDeep(data);
-  dataDeepClone.forEach((component) => {
+
+  // update all versions of components to match current version
+  
+  // remove separators
+  dataDeepClone.forEach(component => {
+    console.log('comp', component);
     removeSeparators(component.children);
   });
 
@@ -53,7 +70,7 @@ function TreeChart({ data }) {
     // but use getBoundingClientRect on initial render
     // (dimensions are null for the first render)
     const { width, height } =
-    dimensions || wrapperRef.current.getBoundingClientRect();
+      dimensions || wrapperRef.current.getBoundingClientRect();
     // transform hierarchical data
     const root = hierarchy(dataDeepClone[canvasId - 1]); // pass in clone here instead of data
     const treeLayout = tree().size([height, width - 125]);

--- a/app/src/tree/TreeChart.tsx
+++ b/app/src/tree/TreeChart.tsx
@@ -13,7 +13,6 @@ function usePrevious(value) {
 }
 
 function TreeChart({ data }) { // data is components from state - passed in from BottomTabs
-  console.log('data', data);
   const [state, dispatch] = useContext(StateContext);
   const canvasId = state.canvasFocus.componentId;
 
@@ -59,7 +58,6 @@ function TreeChart({ data }) { // data is components from state - passed in from
   
   // remove separators
   dataDeepClone.forEach(component => {
-    console.log('comp', component);
     removeSeparators(component.children);
   });
 

--- a/app/src/tree/TreeChart.tsx
+++ b/app/src/tree/TreeChart.tsx
@@ -47,10 +47,6 @@ function TreeChart({ data }) { // data is components from state - passed in from
     return arr;
   };
 
-  // const updateComps = (arr) => {
-  //   for (let i = 0;)
-  // }
-
   // create a deep clone of data to avoid mutating the actual children array in removing separators
   const dataDeepClone = cloneDeep(data);
 

--- a/app/src/tree/TreeChart.tsx
+++ b/app/src/tree/TreeChart.tsx
@@ -38,8 +38,8 @@ function TreeChart({ data }) { // data is components from state - passed in from
       }
       // if element has a children array and that array has length, recursive call
       else if ((arr[i].name === 'div' || arr[i].type === 'Component') && arr[i].children.length) {
-        // if element is a component, replace it with the latest version (to update with new HTML elements)
-        if (arr[i].type === 'Component') arr[i] = data.find(component => component.name === arr[i].name);
+        // if element is a component, replace it with deep clone of latest version (to update with new HTML elements)
+        if (arr[i].type === 'Component') arr[i] = cloneDeep(data.find(component => component.name === arr[i].name));
         removeSeparators(arr[i].children);
       }
     }


### PR DESCRIPTION
**TYPES OF CHANGES**
- [x] Bugfix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Refactor (change that modifies codebase without altering external behavior)
- [x] Non-breaking change (fix or feature that allows existing functionality to continue working)
- [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)

**PURPOSE**
- When a user added components to the canvas, separators would appear in the tree chart. Additionally, when the user modified the added component, only the latest-added version would change on the tree chart.
 
**APPROACH**
To remedy this issue, the removeSeparators function in the TreeChart.tsx file was modified as follows:
- If the splice method is invoked to remove a separator from an array, i is decremented to ensure that all elements are iterated over.
- The condition that checks whether an element is a div now also checks whether an element is a component, to allow recursive calls for components' children arrays.
- Within this conditional block, a second condition checks whether the current element is a condition and, if so, replaces it with a deep clone of the most up-to-date version of the component. This ensures that modifications to components are reflected in all components that have been dropped onto the canvas while preserving separators in the versions of components stored in state.

![tree-chart-fix](https://user-images.githubusercontent.com/67885346/106067914-7cda6780-60b4-11eb-9187-8151f2819fe7.png)