### PR TITLE
Bugfix: Routing in Gatsby and Next modes

### DIFF
--- a/app/src/helperFunctions/generateCode.ts
+++ b/app/src/helperFunctions/generateCode.ts
@@ -119,10 +119,12 @@ const generateUnformattedCode = (
         // route links are for gastby.js and next.js feature. if the user creates a route link and then switches projects, generate code for a normal link instead
         else if (child.type === 'Route Link') {
           if (projectType === 'Next.js') {
-            return `<div><Link href="/${child.name}"><a>${child.name}</a></Link></div>`
+            // if route link points to index, to go endpoint / rather than /index
+            if (child.name === 'index') return `<div><Link href="/"><a>${child.name}</a></Link></div>`;
+            else return `<div><Link href="/${child.name}"><a>${child.name}</a></Link></div>`;
           } else if (projectType === 'Gatsby.js') {
-            return `<div><Link to="/${child.name}">${child.name}</Link></div>`
-            // return `<div><Link href="/${child.name}"><a>${child.name}</a></Link></div>`            
+            if (child.name === 'index') return `<div><Link to="/">${child.name}</Link></div>`;
+            else return `<div><Link to="/${child.name}">${child.name}</Link></div>`;
           } else return `<div><a>${child.name}</a></div>`
         }
       })

--- a/app/src/reducers/componentReducer.ts
+++ b/app/src/reducers/componentReducer.ts
@@ -529,7 +529,7 @@ const reducer = (state: State, action: Action) => {
       });
 
       // also update the name of the root component of the application to fit classic React and next.js conventions
-      if (projectType === 'Next.js') components[0]['name'] = 'index';
+      if (projectType === 'Next.js' || projectType === 'Gatsby.js') components[0]['name'] = 'index';
       else components[0]['name'] = 'App';
 
       return { ...state, components, projectType };


### PR DESCRIPTION
### Types of Changes
- [x] Bugfix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Refactor (change that modifies codebase without altering external behavior)
- [x] Non-breaking change (fix or feature that allows existing functionality to continue working)
- [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)

### Purpose
- When a user added switched to Gatsby mode, the dropdown menu in the "Route Link" box referred to the "index" component as "App," as in classic React mode
- In exported Gatsby and Next applications, route links to the "index" component created links to the "/index" endpoint, causing a blank page to display
 
### Approach
- In componentReducer.tsx, added a condition to change the name of the "App" component to "index" in Gatsby mode (as already applied for Next mode)
- In generateCode.tsx, added conditions to check whether the component subject to the route link is "index" -- if so, link routes to "/" endpoint rather than "/index"

### Screenshots
componentReducer.tsx:
![gatsby-index](https://user-images.githubusercontent.com/67885346/106676438-bfe08300-656b-11eb-9f4f-130960d0f617.png)

generateCode.tsx:
![index-route](https://user-images.githubusercontent.com/67885346/106676459-cb33ae80-656b-11eb-8c12-f0345e56fc18.png)
