### PR TITLE
Fixed style editor/code preview worker bug

### DIFF
--- a/app/src/components/bottom/CodePreview.tsx
+++ b/app/src/components/bottom/CodePreview.tsx
@@ -103,6 +103,9 @@ const CodePreview: React.FC<{
         readOnly={false}
         fontSize={18}
         tabSize={2}
+        setOptions={{
+          useWorker: false
+        }}
       />
     </div>
   );

--- a/app/src/components/bottom/StylesEditor.tsx
+++ b/app/src/components/bottom/StylesEditor.tsx
@@ -87,8 +87,11 @@ const StylesEditor: React.FC<{
         name="Css_div"
         fontSize={16}
         tabSize={2}
-        enableBasicAutocompletion={true}
-        enableLiveAutocompletion={true}
+        setOptions={{
+          useWorker: false,
+          enableBasicAutocompletion: true,
+          enableLiveAutocompletion: true
+        }}
       />
       <Fab className='bttn' onClick={saveCss} color="secondary" aria-label="add">
         <SaveIcon />

--- a/app/src/helperFunctions/zipFiles.ts
+++ b/app/src/helperFunctions/zipFiles.ts
@@ -5,6 +5,7 @@ const zipFiles = (state) => {
   var zip = new JSZip();
   let reacTypeApp = zip.folder('ReacTypeApp');
   let componentFolder = reacTypeApp.folder('componentfolder');
+  reacTypeApp.file('index.html', '<!DOCTYPE html> <html>   <head>     <meta charset="UTF-8" />     <link rel="stylesheet" href="styles.css">     <title>ReacType App</title>   </head>   <body>     <div id="root"></div>   </body> </html>');
   for (let i in state.components){
     componentFolder.file(`${state.components[i].name}.jsx`, state.components[i].code);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/prettier": "^2.6.4",
         "@types/react-redux": "^7.1.24",
         "@types/react-router-dom": "^5.3.3",
-        "ace-builds": "^1.8.1",
+        "ace-builds": "^1.19.0",
         "app-root-path": "^3.0.0",
         "autoprefixer": "^10.4.8",
         "babel-polyfill": "^6.26.0",
@@ -6965,9 +6965,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.16.0.tgz",
-      "integrity": "sha512-EriMhoxdfhh0zKm7icSt8EXekODAOVsYh9fpnlru9ALwf0Iw7J7bpuqLjhi3QRxvVKR7P0teQdJwTvjVMcYHuw=="
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.19.0.tgz",
+      "integrity": "sha512-7iRX9MsxyhMUsqfWpWrJVf7dmv0nQcidOQOhzfYLQnNELdVpaqXVWcewfQqEHP+M0RR2TNie0gqoxPSstUc8Ww=="
     },
     "node_modules/acorn": {
       "version": "8.8.2",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@types/prettier": "^2.6.4",
     "@types/react-redux": "^7.1.24",
     "@types/react-router-dom": "^5.3.3",
-    "ace-builds": "^1.8.1",
+    "ace-builds": "^1.19.0",
     "app-root-path": "^3.0.0",
     "autoprefixer": "^10.4.8",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
- Added a 'set options: {{useWorker: false}}' attribute to the ace editors in both code preview & style editor
- Updated ace-build & react-ace packages
- Added default html file to zip helper for export