### PR TITLE
Revise clicking & dragging functionality of bottom panel

### DIFF
--- a/app/src/components/bottom/BottomPanel.tsx
+++ b/app/src/components/bottom/BottomPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import BottomTabs from './BottomTabs';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 
@@ -6,6 +6,8 @@ const BottomPanel = (props): JSX.Element => {
   let y: number = 0;
   let h: number = 0;
   const node = useRef() as React.MutableRefObject<HTMLDivElement>;
+
+  const [isDragging, setIsDragging] = useState(false);
 
   const mouseDownHandler = (e): void => {
     y = e.clientY;
@@ -28,6 +30,8 @@ const BottomPanel = (props): JSX.Element => {
   };
 
   const mouseMoveHandler = function (e: MouseEvent): void {
+    if (!props.bottomShow) return; // prevent drag calc to occur when bottom menu is not showing
+
     const dy = y - e.clientY;
 
     const newVal = h + dy;
@@ -37,6 +41,8 @@ const BottomPanel = (props): JSX.Element => {
   };
 
   const mouseUpHandler = function () {
+    // puts false in callback queue after OnDragStart sets to true (b/c react 17 doesn't have onDragEnd)
+    setTimeout(() => setIsDragging(false), 0);
     document.removeEventListener('mousemove', mouseMoveHandler);
     document.removeEventListener('mouseup', mouseUpHandler);
     window.removeEventListener('message', handleIframeMessage);
@@ -53,7 +59,9 @@ const BottomPanel = (props): JSX.Element => {
         <div
           id="resize-drag"
           onMouseDown={mouseDownHandler}
-          onClick={() => props.setBottomShow(!props.bottomShow)}
+          draggable
+          onDragStart={() => setIsDragging(true)}
+          onClick={() => !isDragging && props.setBottomShow(!props.bottomShow)}
           tabIndex={0}
         >
           {props.bottomShow ? <ExpandMore /> : <ExpandLess />}

--- a/app/src/components/bottom/BottomPanel.tsx
+++ b/app/src/components/bottom/BottomPanel.tsx
@@ -28,7 +28,6 @@ const BottomPanel = (props): JSX.Element => {
   };
 
   const mouseMoveHandler = function (e: MouseEvent): void {
-
     const dy = y - e.clientY;
 
     const newVal = h + dy;
@@ -54,7 +53,7 @@ const BottomPanel = (props): JSX.Element => {
         <div
           id="resize-drag"
           onMouseDown={mouseDownHandler}
-          onClick={() => props.setBottomShow(true)}
+          onClick={() => props.setBottomShow(!props.bottomShow)}
           tabIndex={0}
         >
           {props.bottomShow ? <ExpandMore /> : <ExpandLess />}

--- a/app/src/components/bottom/BottomTabs.tsx
+++ b/app/src/components/bottom/BottomTabs.tsx
@@ -39,6 +39,10 @@ const BottomTabs = (props): JSX.Element => {
 
   arrow.renderArrow(state.canvasFocus?.childId);
 
+  const showBottomPanel = () => {
+    props.setBottomShow(true);
+  };
+
   return (
     <div
       className={`${classes.root} ${classes.rootLight}`}
@@ -46,9 +50,6 @@ const BottomTabs = (props): JSX.Element => {
         backgroundColor: '#191919',
         zIndex: 1,
         borderTop: '2px solid grey'
-      }}
-      onClick={() => {
-        props.setBottomShow(true);
       }}
     >
       <Box
@@ -69,31 +70,37 @@ const BottomTabs = (props): JSX.Element => {
             disableRipple
             classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
             label="Creation Panel"
+            onClick={showBottomPanel}
           />
           <Tab
             disableRipple
             classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
             label="Customization"
+            onClick={showBottomPanel}
           />
           <Tab
             disableRipple
             classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
             label="CSS Editor"
+            onClick={showBottomPanel}
           />
           <Tab
             disableRipple
             classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
             label="Component Tree"
+            onClick={showBottomPanel}
           />
           <Tab
             disableRipple
             classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
             label="Context Manager"
+            onClick={showBottomPanel}
           />
           <Tab
             disableRipple
             classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
             label="State Manager"
+            onClick={showBottomPanel}
           />
         </Tabs>
         <div className={classes.projectTypeWrapper}>

--- a/app/src/components/main/Canvas.tsx
+++ b/app/src/components/main/Canvas.tsx
@@ -363,6 +363,6 @@ const Canvas = (props: {}): JSX.Element => {
       </label>
     </div>
   );
-}
+};
 
 export default Canvas;

--- a/app/src/containers/MainContainer.tsx
+++ b/app/src/containers/MainContainer.tsx
@@ -109,7 +109,16 @@ const MainContainer = (props): JSX.Element => {
     setBottomShow(false);
   };
 
-  let showPanel = bottomShow ? 'bottom-show' : 'bottom-hide';
+  const hideBottomPanelStyles = {
+    maxHeight: '64px',
+    boxSizing: 'border-box',
+    transition: 'all 0.5s ease-in-out'
+  };
+
+  const showBottomPanelStyles = {
+    maxHeight: '100%',
+    transition: 'all 0.5s ease-in-out'
+  };
 
   return (
     <div className="main-container" style={style} ref={containerRef}>
@@ -117,7 +126,10 @@ const MainContainer = (props): JSX.Element => {
         <CanvasContainer isThemeLight={props.isThemeLight} />
         <DemoRender />
       </div>
-      <div className={showPanel} ref={ref}>
+      <div
+        ref={ref}
+        style={bottomShow ? showBottomPanelStyles : hideBottomPanelStyles}
+      >
         <BottomPanel
           bottomShow={bottomShow}
           setBottomShow={setBottomShow}

--- a/app/src/public/styles/style.css
+++ b/app/src/public/styles/style.css
@@ -502,25 +502,6 @@ BOTTOM PANEL
 /////////////////////////////////////////////////////
 */
 
-.bottom-hide {
-  max-height: 64px;
-  box-sizing: border-box;
-  transition: all 0.5s ease-in-out;
-}
-
-.bottom-show {
-  max-height: 100%;
-  transition: all 0.5s ease-in-out;
-}
-
-.bottom-hide:focus-within {
-  max-height: 100%;
-}
-/* 
-.bottom-hide:hover {
-  max-height: 100%;
-} */
-
 .tab-content {
   height: calc(100% - 76px);
   width: 100%;


### PR DESCRIPTION
# Description

Please describe the issue of the pull request and the changes

<!-- Please include the following information:
- Previous the bottom panel was changed with non-dynamic CSS.  This has now been updated to integrate dynamic CSS styling within the React components.  Utilized state and props drilling to enable better click functionality to expand and collapse the bottom menu.  Introduced piece of React state that tracks when a drag of the bottom panel starts and state is changed again when function is pushed to callback queue to change state back when the drag ends.  `setTimeout` is used to enable this function to go onto the callback queue - this approach was used due to a React 17 limitation that does not allow a JSX attribute to track when a mouse drag ends.
- No dependencies required for this change.
-->

## Type of Change

Please check the options that apply

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has the Changes Been Tested?

<!--
Tested the feature through clicking and dragging the bottom panel rendered on the web browser.
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Changes included in this pull request covers minimal topic
- [x] I have performed a self-review of my code
- [x] I have commented my code properly, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
