### PR TITLE
Nested elements on cavas can now be dragged anywhere except into their own children

### DIFF
--- a/app/src/components/main/DeleteButton.tsx
+++ b/app/src/components/main/DeleteButton.tsx
@@ -5,7 +5,7 @@ import { deleteChild } from '../../redux/reducers/slice/appStateSlice';
 import { RootState } from '../../redux/store';
 import { emitEvent } from '../../helperFunctions/socket';
 
-function DeleteButton({ id, name }: DeleteButtons) {
+function DeleteButton({ id, name, onClickHandler }: DeleteButtons) {
   const contextParam = useSelector((store: RootState) => store.contextSlice);
 
   const roomCode = useSelector((store: RootState) => store.roomSlice.roomCode);
@@ -33,6 +33,7 @@ function DeleteButton({ id, name }: DeleteButtons) {
         id={'btn' + id}
         onClick={(event) => {
           event.stopPropagation();
+          onClickHandler(event);
           deleteHTMLtype(id);
         }}
       >

--- a/app/src/components/main/DeleteButton.tsx
+++ b/app/src/components/main/DeleteButton.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { DeleteButtons } from '../../interfaces/Interfaces';
 import { useDispatch, useSelector } from 'react-redux';
 import { deleteChild } from '../../redux/reducers/slice/appStateSlice';
 import { RootState } from '../../redux/store';
 import { emitEvent } from '../../helperFunctions/socket';
+import { Delete } from '@mui/icons-material';
 
 function DeleteButton({ id, name, onClickHandler }: DeleteButtons) {
   const contextParam = useSelector((store: RootState) => store.contextSlice);
@@ -37,7 +38,7 @@ function DeleteButton({ id, name, onClickHandler }: DeleteButtons) {
           deleteHTMLtype(id);
         }}
       >
-        x
+        <Delete className="deleteIcon" />
       </button>
     </div>
   );

--- a/app/src/components/main/DeleteButton.tsx
+++ b/app/src/components/main/DeleteButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { DeleteButtons } from '../../interfaces/Interfaces';
 import { useDispatch, useSelector } from 'react-redux';
 import { deleteChild } from '../../redux/reducers/slice/appStateSlice';

--- a/app/src/components/main/DirectChildHTML.tsx
+++ b/app/src/components/main/DirectChildHTML.tsx
@@ -80,6 +80,7 @@ function DirectChildHTML({ childId, name, type, typeId, style }: ChildElement) {
         <DeleteButton
           id={childId}
           name={name[0].toLowerCase() + name.slice(1)}
+          onClickHandler={onClickHandler}
         />
       </span>
     </div>

--- a/app/src/components/main/DirectChildHTMLNestable.tsx
+++ b/app/src/components/main/DirectChildHTMLNestable.tsx
@@ -225,7 +225,11 @@ function DirectChildHTMLNestable({
           {attributes && attributes.compLink ? ` ${attributes.compLink}` : ''}
         </strong>
         {routeButton}
-        <DeleteButton id={childId} name={name} />
+        <DeleteButton
+          id={childId}
+          name={name}
+          onClickHandler={onClickHandler}
+        />
       </span>
       {renderChildren(children)}
     </div>

--- a/app/src/components/main/SeparatorChild.tsx
+++ b/app/src/components/main/SeparatorChild.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../redux/reducers/slice/appStateSlice';
 import { emitEvent } from '../../helperFunctions/socket';
 
-function DirectChildHTMLNestable({
+function SeparatorChild({
   childId,
   type,
   typeId,
@@ -165,4 +165,4 @@ function DirectChildHTMLNestable({
   );
 }
 
-export default DirectChildHTMLNestable;
+export default SeparatorChild;

--- a/app/src/helperFunctions/changePositionValidation.ts
+++ b/app/src/helperFunctions/changePositionValidation.ts
@@ -18,7 +18,11 @@ const validateNewParent = (
     nestedParent = false
   ): boolean => {
     for (const element of array) {
-      if (element.childId === toTargetParentId && nestedChild === true)
+      if (
+        element.childId === toTargetParentId &&
+        nestedChild === true &&
+        element.typeId > 1000 // check if not a separator (1000) or previously dragged component (> 1000)
+      )
         return (nestedParent = true);
       else if (
         element.childId === currentChildId &&

--- a/app/src/interfaces/Interfaces.ts
+++ b/app/src/interfaces/Interfaces.ts
@@ -116,6 +116,7 @@ export interface LoginInt {
 export interface DeleteButtons {
   id: number;
   name: string;
+  onClickHandler: (event: any) => void;
 }
 export interface StatePropsPanelProps {
   selectHandler: (table: any) => void;

--- a/app/src/public/styles/style.css
+++ b/app/src/public/styles/style.css
@@ -746,9 +746,14 @@ CANVAS WINDOW
     0px 2px 2px 0px rgb(0 0 0 / 14%), 0px 1px 5px 0px rgb(0 0 0 / 12%);
 }
 
-.delete-button-empty:hover {
+.deleteIcon {
+  font-size: 18px;
+  color: #4a4a4a;
+  cursor: pointer;
+}
+
+.deleteIcon:hover {
   color: white;
-  background-color: rgba(0, 100, 0, 0.4);
 }
 
 .componentContainer {


### PR DESCRIPTION
# Description

- Parent element (e.g. div) with nested children inside of it can now be drag and dropped to be repositioned, except inside of their own children.
- Rename function inside of SeparatorChild.tsx from DirectChildHTMLNestable to SeparatorChild to not cause confusion, as a different DirectChildHTMLNestable function already exists inside DirectChildHTMLNestable.tsx
- No dependencies are required for this change.

<!-- Please include the following information:
- Parent element (e.g. div) with nested children inside of it can now be drag and dropped to be repositioned, except inside of their own children.
- Rename function inside of SeparatorChild.tsx from DirectChildHTMLNestable to SeparatorChild to not cause confusion, as a different DirectChildHTMLNestable function already exists inside DirectChildHTMLNestable.tsx
- No dependencies are required for this change.
-->

## Type of Change

Please check the options that apply

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has the Changes Been Tested?
Tested through user interface by dragging nested elements and checking their data with console.logs
Tested through collaboration room as well to make sure (socket.io) emit and event listeners work with these changes as well

<!--
Tested through user interface by dragging nested elements and checking their data with console.logs
Tested through collaboration room as well to make sure (socket.io) emit and event listeners work with these changes as well
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Changes included in this pull request covers minimal topic
- [x] I have performed a self-review of my code
- [x] I have commented my code properly, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
