### PR TITLE
Add BottomTab expand functionality to Live Chat button + CSS update

### DIFF
--- a/app/src/components/bottom/BottomTabs.tsx
+++ b/app/src/components/bottom/BottomTabs.tsx
@@ -108,6 +108,7 @@ const BottomTabs = (props): JSX.Element => {
             disableRipple
             classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
             label="Live Chat"
+            onClick={showBottomPanel}
           />
         </Tabs>
         <div className={classes.projectTypeWrapper}>
@@ -121,13 +122,13 @@ const BottomTabs = (props): JSX.Element => {
               onChange={handleProjectChange}
               MenuProps={{ disablePortal: true }}
             >
-              <MenuItem style={{ color: 'black' }} value={'Classic React'}>
+              <MenuItem style={{ color: 'white' }} value={'Classic React'}>
                 Classic React
               </MenuItem>
-              <MenuItem style={{ color: 'black' }} value={'Gatsby.js'}>
+              <MenuItem style={{ color: 'white' }} value={'Gatsby.js'}>
                 Gatsby.js
               </MenuItem>
-              <MenuItem style={{ color: 'black' }} value={'Next.js'}>
+              <MenuItem style={{ color: 'white' }} value={'Next.js'}>
                 Next.js
               </MenuItem>
             </Select>


### PR DESCRIPTION
# Description

Add BottomTab expand functionality to Live Chat button and change font color of Classic React, Gatsby.js, and Next.js to white

<!-- Please include the following information:
- A summary of the changes and the related issue.
- Relevant motivation and context.
- Any dependencies that are required for this change.
-->

## Type of Change

Please check the options that apply

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has the Changes Been Tested?
Tested by clicking "Live Chat" to expand menu.  Also, viewed Classic React, Gatsby.js, and Next.js change to a white font color.

<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Changes included in this pull request covers minimal topic
- [x] I have performed a self-review of my code
- [ ] I have commented my code properly, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
