### PR TITLE
[Bug Fix] Clean Chat History When Leaving Collaboration Room

### DIFF
--- a/app/src/components/left/RoomsContainer.tsx
+++ b/app/src/components/left/RoomsContainer.tsx
@@ -41,7 +41,8 @@ import {
   setUserJoined,
   setUserList,
   setMessages,
-  setPassword
+  setPassword,
+  setEmptyMessages
 } from '../../redux/reducers/slice/roomSlice';
 import { codePreviewCooperative } from '../../redux/reducers/slice/codePreviewSlice';
 import { cooperativeStyle } from '../../redux/reducers/slice/styleSlice';
@@ -342,6 +343,7 @@ const RoomsContainer = () => {
     dispatch(setUserJoined(false)); //false: join room UI appear
     dispatch(resetState(''));
     dispatch(setPassword(''));
+    dispatch(setEmptyMessages([]));
   };
 
   const checkInputField = (...inputs) => {

--- a/app/src/redux/reducers/slice/roomSlice.ts
+++ b/app/src/redux/reducers/slice/roomSlice.ts
@@ -28,6 +28,9 @@ const roomSlice = createSlice({
     setMessages: (state, action) => {
       state.messages = [...state.messages, action.payload];
     },
+    setEmptyMessages: (state, action) => {
+      state.messages = [];
+    },
     setPassword: (state, action) => {
       state.password = action.payload;
     }
@@ -40,6 +43,7 @@ export const {
   setUserList,
   setUserJoined,
   setMessages,
+  setEmptyMessages,
   setPassword
 } = roomSlice.actions;
 


### PR DESCRIPTION
# Description

Please describe the issue of the pull request and the changes

Previously when leaving the chatroom, the chat history was not cleaned. As a result, when users rejoin the same room after leaving, they still have the historical chat

<!-- Please include the following information:
- A summary of the changes and the related issue.
- Relevant motivation and context.
- Any dependencies that are required for this change.
-->

Changes in this PR:
- Add action `setEmptyMessages` in `roomSlice`
- Dispatch `setEmptyMessages` action when user leaves the collaboration room

## Type of Change

Please check the options that apply

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has the Changes Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration
-->

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Changes included in this pull request covers minimal topic
- [x] I have performed a self-review of my code
- [x] I have commented my code properly, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
